### PR TITLE
fix: fix the issue where rules doesn't apply correct timing

### DIFF
--- a/yashiki-ipc/src/command.rs
+++ b/yashiki-ipc/src/command.rs
@@ -296,6 +296,7 @@ pub enum Command {
         action: RuleAction,
     },
     ListRules,
+    ApplyRules,
 
     // Control
     Quit,


### PR DESCRIPTION
  - Fix rules not being applied to existing windows at startup
  - Fix new windows with tag rules not being hidden when assigned to non-visible tags

  ## Changes

  - Add `ApplyRules` command, sent automatically after init script completes
  - Add hide handling to `apply_rules_to_new_window()`

