### PR TITLE
feat: add window-toggle-float

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,6 +136,7 @@ yashiki window-focus prev         # Focus previous window
 yashiki window-focus left         # Focus window to the left
 yashiki window-swap next          # Swap with next window (not yet implemented)
 yashiki window-toggle-fullscreen  # Toggle fullscreen for focused window (AeroSpace-style)
+yashiki window-toggle-float       # Toggle floating state for focused window
 yashiki focused-window            # Get focused window ID
 yashiki output-focus next         # Focus next display
 yashiki output-focus prev         # Focus previous display
@@ -216,6 +217,7 @@ yashiki bind alt-l layout-cmd inc-main-ratio
 yashiki bind alt-o output-focus next
 yashiki bind alt-shift-o output-send next
 yashiki bind alt-f window-toggle-fullscreen
+yashiki bind alt-shift-f window-toggle-float
 
 # Gap configuration (--layout sends to specific engine, without sends to current)
 yashiki layout-cmd --layout tatami set-inner-gap 10
@@ -304,7 +306,7 @@ yashiki bind alt-s exec-or-focus --app-name Safari "open -a Safari"
 
 ### Not Yet Implemented
 - `WindowSwap` command - CLI parsing done, but handler not implemented
-- `WindowClose` / `WindowToggleFloat`
+- `WindowClose`
 
 ## Development Notes
 

--- a/yashiki/src/app.rs
+++ b/yashiki/src/app.rs
@@ -690,6 +690,18 @@ fn process_command(
             }
         }
 
+        // Float toggle
+        Command::WindowToggleFloat => {
+            if let Some((display_id, _is_floating, _window_id, _pid)) = state.toggle_focused_float()
+            {
+                // Just retile - window maintains current position when floating,
+                // or gets positioned by layout when unfloating
+                CommandResult::ok_with_effects(vec![Effect::RetileDisplays(vec![display_id])])
+            } else {
+                CommandResult::ok()
+            }
+        }
+
         // Send to output - returns displays that need retiling
         Command::OutputSend { direction } => {
             let displays_to_retile = state.send_to_output(*direction);

--- a/yashiki/src/core/state.rs
+++ b/yashiki/src/core/state.rs
@@ -667,6 +667,22 @@ impl State {
         ))
     }
 
+    /// Toggle floating state for focused window.
+    /// Returns Some((display_id, is_now_floating, window_id, pid)) if toggled successfully.
+    pub fn toggle_focused_float(&mut self) -> Option<(DisplayId, bool, u32, i32)> {
+        let focused_id = self.focused?;
+        let window = self.windows.get_mut(&focused_id)?;
+
+        window.is_floating = !window.is_floating;
+        tracing::info!(
+            "Toggle floating for window {}: {}",
+            window.id,
+            window.is_floating
+        );
+
+        Some((window.display_id, window.is_floating, window.id, window.pid))
+    }
+
     pub fn focus_window(&self, direction: Direction) -> Option<(WindowId, i32)> {
         let visible_tags = self.visible_tags();
         let visible: Vec<_> = self

--- a/yashiki/src/main.rs
+++ b/yashiki/src/main.rs
@@ -42,6 +42,7 @@ enum SubCommand {
     WindowFocus(WindowFocusCmd),
     WindowSwap(WindowSwapCmd),
     WindowToggleFullscreen(WindowToggleFullscreenCmd),
+    WindowToggleFloat(WindowToggleFloatCmd),
     OutputFocus(OutputFocusCmd),
     OutputSend(OutputSendCmd),
     Retile(RetileCmd),
@@ -169,6 +170,11 @@ struct WindowSwapCmd {
 #[derive(FromArgs)]
 #[argh(subcommand, name = "window-toggle-fullscreen")]
 struct WindowToggleFullscreenCmd {}
+
+/// Toggle floating state for focused window
+#[derive(FromArgs)]
+#[argh(subcommand, name = "window-toggle-float")]
+struct WindowToggleFloatCmd {}
 
 /// Focus the next or previous display
 #[derive(FromArgs)]
@@ -535,6 +541,7 @@ fn to_command(subcmd: SubCommand) -> Result<Command> {
             direction: parse_direction(&cmd.direction)?,
         }),
         SubCommand::WindowToggleFullscreen(_) => Ok(Command::WindowToggleFullscreen),
+        SubCommand::WindowToggleFloat(_) => Ok(Command::WindowToggleFloat),
         SubCommand::OutputFocus(cmd) => Ok(Command::OutputFocus {
             direction: parse_output_direction(&cmd.direction)?,
         }),
@@ -678,6 +685,7 @@ fn parse_command(args: &[String]) -> Result<Command> {
             })
         }
         "window-toggle-fullscreen" => Ok(Command::WindowToggleFullscreen),
+        "window-toggle-float" => Ok(Command::WindowToggleFloat),
         "output-focus" => {
             let cmd: OutputFocusCmd = from_argh(cmd_name, &cmd_args)?;
             Ok(Command::OutputFocus {


### PR DESCRIPTION
  Add `window-toggle-float` command to toggle floating state for the focused window.

  - Floating windows are excluded from tiling layout
  - Window maintains its current position when floated
  - Re-enters layout when unfloated

