### PR TITLE
feat: add window-close cmd

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,6 +137,7 @@ yashiki window-focus left         # Focus window to the left
 yashiki window-swap next          # Swap with next window (not yet implemented)
 yashiki window-toggle-fullscreen  # Toggle fullscreen for focused window (AeroSpace-style)
 yashiki window-toggle-float       # Toggle floating state for focused window
+yashiki window-close              # Close the focused window
 yashiki focused-window            # Get focused window ID
 yashiki output-focus next         # Focus next display
 yashiki output-focus prev         # Focus previous display
@@ -218,6 +219,7 @@ yashiki bind alt-o output-focus next
 yashiki bind alt-shift-o output-send next
 yashiki bind alt-f window-toggle-fullscreen
 yashiki bind alt-shift-f window-toggle-float
+yashiki bind alt-shift-c window-close
 
 # Gap configuration (--layout sends to specific engine, without sends to current)
 yashiki layout-cmd --layout tatami set-inner-gap 10
@@ -306,7 +308,6 @@ yashiki bind alt-s exec-or-focus --app-name Safari "open -a Safari"
 
 ### Not Yet Implemented
 - `WindowSwap` command - CLI parsing done, but handler not implemented
-- `WindowClose`
 
 ## Development Notes
 

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ yashiki window-move-to-tag 1     # Move focused window to tag 1
 yashiki window-toggle-tag 2      # Toggle tag 2 on focused window
 ```
 
-### Window Focus
+### Window Operations
 
 ```sh
 yashiki window-focus next        # Focus next window
@@ -166,6 +166,9 @@ yashiki window-focus left        # Focus window to the left
 yashiki window-focus right       # Focus window to the right
 yashiki window-focus up          # Focus window above
 yashiki window-focus down        # Focus window below
+yashiki window-toggle-fullscreen # Toggle fullscreen (AeroSpace-style)
+yashiki window-toggle-float      # Toggle floating state
+yashiki window-close             # Close focused window
 ```
 
 ### Multi-Monitor

--- a/yashiki/src/app.rs
+++ b/yashiki/src/app.rs
@@ -702,6 +702,22 @@ fn process_command(
             }
         }
 
+        // Window close
+        Command::WindowClose => {
+            if let Some(focused_id) = state.focused {
+                if let Some(window) = state.windows.get(&focused_id) {
+                    CommandResult::ok_with_effects(vec![Effect::CloseWindow {
+                        window_id: focused_id,
+                        pid: window.pid,
+                    }])
+                } else {
+                    CommandResult::error("Focused window not found")
+                }
+            } else {
+                CommandResult::error("No focused window")
+            }
+        }
+
         // Send to output - returns displays that need retiling
         Command::OutputSend { direction } => {
             let displays_to_retile = state.send_to_output(*direction);
@@ -994,6 +1010,9 @@ fn execute_effects<M: WindowManipulator>(
                 height,
             } => {
                 manipulator.set_window_dimensions(window_id, pid, width, height);
+            }
+            Effect::CloseWindow { window_id, pid } => {
+                manipulator.close_window(window_id, pid);
             }
             Effect::ApplyFullscreen {
                 window_id,

--- a/yashiki/src/effect.rs
+++ b/yashiki/src/effect.rs
@@ -21,6 +21,10 @@ pub enum Effect {
         width: u32,
         height: u32,
     },
+    CloseWindow {
+        window_id: u32,
+        pid: i32,
+    },
     ApplyFullscreen {
         window_id: u32,
         pid: i32,

--- a/yashiki/src/macos/accessibility.rs
+++ b/yashiki/src/macos/accessibility.rs
@@ -85,6 +85,7 @@ const AX_VALUE_TYPE_CGSIZE: u32 = 2;
 
 mod action {
     pub const RAISE: &str = "AXRaise";
+    pub const PRESS: &str = "AXPress";
 }
 
 mod attr {
@@ -95,6 +96,7 @@ mod attr {
     pub const POSITION: &str = "AXPosition";
     pub const SIZE: &str = "AXSize";
     pub const MINIMIZED: &str = "AXMinimized";
+    pub const CLOSE_BUTTON: &str = "AXCloseButton";
 }
 
 pub mod notification {
@@ -307,6 +309,23 @@ impl AXUIElement {
         } else {
             Err(err)
         }
+    }
+
+    pub fn press(&self) -> Result<(), AXError> {
+        let action = CFString::new(action::PRESS);
+        let err = unsafe {
+            AXUIElementPerformAction(self.as_concrete_TypeRef(), action.as_concrete_TypeRef())
+        };
+        if err == AX_ERROR_SUCCESS {
+            Ok(())
+        } else {
+            Err(err)
+        }
+    }
+
+    pub fn close_button(&self) -> Result<AXUIElement, AXError> {
+        let value = self.get_attribute(attr::CLOSE_BUTTON)?;
+        Ok(unsafe { AXUIElement::wrap_under_create_rule(value as AXUIElementRef) })
     }
 }
 

--- a/yashiki/src/main.rs
+++ b/yashiki/src/main.rs
@@ -43,6 +43,7 @@ enum SubCommand {
     WindowSwap(WindowSwapCmd),
     WindowToggleFullscreen(WindowToggleFullscreenCmd),
     WindowToggleFloat(WindowToggleFloatCmd),
+    WindowClose(WindowCloseCmd),
     OutputFocus(OutputFocusCmd),
     OutputSend(OutputSendCmd),
     Retile(RetileCmd),
@@ -175,6 +176,11 @@ struct WindowToggleFullscreenCmd {}
 #[derive(FromArgs)]
 #[argh(subcommand, name = "window-toggle-float")]
 struct WindowToggleFloatCmd {}
+
+/// Close the focused window
+#[derive(FromArgs)]
+#[argh(subcommand, name = "window-close")]
+struct WindowCloseCmd {}
 
 /// Focus the next or previous display
 #[derive(FromArgs)]
@@ -542,6 +548,7 @@ fn to_command(subcmd: SubCommand) -> Result<Command> {
         }),
         SubCommand::WindowToggleFullscreen(_) => Ok(Command::WindowToggleFullscreen),
         SubCommand::WindowToggleFloat(_) => Ok(Command::WindowToggleFloat),
+        SubCommand::WindowClose(_) => Ok(Command::WindowClose),
         SubCommand::OutputFocus(cmd) => Ok(Command::OutputFocus {
             direction: parse_output_direction(&cmd.direction)?,
         }),
@@ -686,6 +693,7 @@ fn parse_command(args: &[String]) -> Result<Command> {
         }
         "window-toggle-fullscreen" => Ok(Command::WindowToggleFullscreen),
         "window-toggle-float" => Ok(Command::WindowToggleFloat),
+        "window-close" => Ok(Command::WindowClose),
         "output-focus" => {
             let cmd: OutputFocusCmd = from_argh(cmd_name, &cmd_args)?;
             Ok(Command::OutputFocus {


### PR DESCRIPTION
  Add `window-close` command to close the focused window.

  - Uses Accessibility API (AXCloseButton + AXPress action)
  - CLI: `yashiki window-close`
  - Binding example: `yashiki bind alt-shift-c window-close`

