### PR TITLE
feat: support code signing with self-signed certificate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,8 +72,40 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      - name: Install signing certificate
+        id: signing
+        env:
+          CERTIFICATE_P12: ${{ secrets.CERTIFICATE_P12 }}
+          CERTIFICATE_PASSWORD: ${{ secrets.CERTIFICATE_PASSWORD }}
+        run: |
+          if [ -z "$CERTIFICATE_P12" ]; then
+            echo "No signing certificate configured, using ad-hoc signing"
+            echo "identity=-" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          KEYCHAIN_PATH=$RUNNER_TEMP/build.keychain
+          KEYCHAIN_PASSWORD=$(openssl rand -base64 32)
+
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          echo "$CERTIFICATE_P12" | base64 --decode > $RUNNER_TEMP/cert.p12
+          security import $RUNNER_TEMP/cert.p12 -k "$KEYCHAIN_PATH" \
+            -P "$CERTIFICATE_PASSWORD" -T /usr/bin/codesign
+          rm -f $RUNNER_TEMP/cert.p12
+
+          security set-key-partition-list -S apple-tool:,apple: \
+            -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security list-keychains -d user -s "$KEYCHAIN_PATH" login.keychain
+
+          echo "identity=yashiki-codesign-certificate" >> "$GITHUB_OUTPUT"
+
       - name: Build .app bundle
         run: ./scripts/build-app.sh --target ${{ matrix.target }} --release
+        env:
+          CODESIGN_IDENTITY: ${{ steps.signing.outputs.identity }}
 
       - name: Get version
         id: version

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -132,9 +132,10 @@ chmod +x "${APP_DIR}/Contents/MacOS/yashiki-launcher"
 # Generate Info.plist
 sed "s/VERSION_PLACEHOLDER/${VERSION}/g" "${PROJECT_ROOT}/Info.plist.template" > "${APP_DIR}/Contents/Info.plist"
 
-# Ad-hoc code signing
-echo "Signing ${APP_NAME}..."
-codesign --force --deep -s - "${APP_DIR}"
+# Code signing (use CODESIGN_IDENTITY if set, otherwise ad-hoc signing)
+CODESIGN_IDENTITY="${CODESIGN_IDENTITY:--}"
+echo "Signing ${APP_NAME} with identity: ${CODESIGN_IDENTITY}"
+codesign --force --deep -s "$CODESIGN_IDENTITY" "${APP_DIR}"
 
 echo "Created: ${APP_DIR}"
 


### PR DESCRIPTION
  Enable code signing with a self-signed certificate to preserve Accessibility permissions across Homebrew updates.

  - `CODESIGN_IDENTITY` env var in build-app.sh (falls back to ad-hoc signing)
  - Certificate import step in release workflow
  - Requires `CERTIFICATE_P12` and `CERTIFICATE_PASSWORD` secrets (optional)

