### PR TITLE
fix: use Tag::from_mask() for rule tag application

### DIFF
--- a/yashiki/src/core/state.rs
+++ b/yashiki/src/core/state.rs
@@ -1094,7 +1094,7 @@ impl State {
         // Modify the window
         if let Some(window) = self.windows.get_mut(&window_id) {
             if let Some(tag_mask) = rule_result.tags {
-                window.tags = Tag::new(tag_mask);
+                window.tags = Tag::from_mask(tag_mask);
                 tracing::info!(
                     "Applied rule: window {} tags set to {}",
                     window_id,
@@ -1253,7 +1253,7 @@ impl State {
             let rule_result = self.apply_rules_to_window(&app_name, app_id.as_deref(), &title);
 
             // Check if any rules matched that would change tags or display_id
-            let new_tags = rule_result.tags.map(Tag::new);
+            let new_tags = rule_result.tags.map(Tag::from_mask);
             let new_display_id = rule_result.display_id;
 
             let tags_changed = new_tags.is_some() && new_tags != Some(original_tags);
@@ -1263,7 +1263,7 @@ impl State {
             // Modify the window
             if let Some(window) = self.windows.get_mut(&window_id) {
                 if let Some(tag_mask) = rule_result.tags {
-                    window.tags = Tag::new(tag_mask);
+                    window.tags = Tag::from_mask(tag_mask);
                     tracing::info!(
                         "Applied rule: window {} ({}) tags set to {}",
                         window_id,


### PR DESCRIPTION
  Fix crash when applying rules with tags bitmask > 32 (e.g., `tags $((1<<9))`).

  `RuleAction::Tags` stores tags as bitmask, but the code incorrectly used `Tag::new()` which expects a tag number (1-32). Changed to `Tag::from_mask()` which accepts bitmask directly.

