### PR TITLE
feat: add cursor warp (mouse follows focus)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ macOS tiling window manager written in Rust.
 - **External layout engines** - Stdin/stdout JSON protocol lets you write custom layouts in any language
 - **Multi-monitor support** - Each display has independent tags
 - **Window rules** - Automatically configure windows by app name, bundle identifier, or title
+- **Cursor warp** - Mouse follows focus (configurable: disabled, on-output-change, on-focus-change)
 - **No SIP disable required** - Uses only public Accessibility API
 - **Shell script configuration** - Config is just a shell script (`~/.config/yashiki/init`)
 
@@ -75,6 +76,9 @@ cargo install --path yashiki-layout-byobu    # Accordion layout
    yashiki layout-set-default tatami
    yashiki layout-cmd --layout tatami set-outer-gap 10
    yashiki layout-cmd --layout tatami set-inner-gap 10
+
+   # Cursor warp (mouse follows focus)
+   yashiki set-cursor-warp on-focus-change
 
    # Tag bindings (tag N = bitmask $((1<<(N-1))))
    for i in 1 2 3 4 5 6 7 8 9; do
@@ -202,6 +206,17 @@ yashiki list-outputs             # List all displays
 yashiki get-state                # Get current state
 yashiki exec "open -a Safari"    # Execute command
 yashiki exec-or-focus --app-name Safari "open -a Safari"  # Focus or launch
+```
+
+### Cursor Warp
+
+Control whether mouse cursor follows window focus.
+
+```sh
+yashiki set-cursor-warp disabled          # Don't move cursor (default)
+yashiki set-cursor-warp on-output-change  # Move cursor when switching displays
+yashiki set-cursor-warp on-focus-change   # Always move cursor to focused window
+yashiki get-cursor-warp                   # Get current mode
 ```
 
 ### Exec Path

--- a/yashiki-ipc/src/command.rs
+++ b/yashiki-ipc/src/command.rs
@@ -1,5 +1,15 @@
 use serde::{Deserialize, Serialize};
 
+/// Cursor warp mode - controls when the mouse cursor follows focus
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum CursorWarpMode {
+    #[default]
+    Disabled,
+    OnOutputChange,
+    OnFocusChange,
+}
+
 /// Glob pattern for matching strings.
 /// Supports: exact match, prefix (*suffix), suffix (prefix*), contains (*middle*)
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -298,6 +308,12 @@ pub enum Command {
     ListRules,
     ApplyRules,
 
+    // Cursor warp
+    SetCursorWarp {
+        mode: CursorWarpMode,
+    },
+    GetCursorWarp,
+
     // Control
     Quit,
 }
@@ -340,6 +356,7 @@ pub enum Response {
     WindowId { id: Option<u32> },
     Layout { layout: String },
     ExecPath { path: String },
+    CursorWarp { mode: CursorWarpMode },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/yashiki-ipc/src/lib.rs
+++ b/yashiki-ipc/src/lib.rs
@@ -2,7 +2,8 @@ pub mod command;
 pub mod layout;
 
 pub use command::{
-    BindingInfo, Command, Direction, GlobPattern, OutputDirection, OutputInfo, OutputSpecifier,
-    Response, RuleAction, RuleInfo, RuleMatcher, StateInfo, WindowInfo, WindowRule,
+    BindingInfo, Command, CursorWarpMode, Direction, GlobPattern, OutputDirection, OutputInfo,
+    OutputSpecifier, Response, RuleAction, RuleInfo, RuleMatcher, StateInfo, WindowInfo,
+    WindowRule,
 };
 pub use layout::{LayoutMessage, LayoutResult, WindowGeometry};

--- a/yashiki/src/core/state.rs
+++ b/yashiki/src/core/state.rs
@@ -5,7 +5,8 @@ use crate::macos::DisplayId;
 use crate::platform::WindowSystem;
 use std::collections::{HashMap, HashSet};
 use yashiki_ipc::{
-    Direction, OutputDirection, OutputSpecifier, RuleAction, RuleMatcher, WindowRule,
+    CursorWarpMode, Direction, OutputDirection, OutputSpecifier, RuleAction, RuleMatcher,
+    WindowRule,
 };
 
 /// Result of applying rules to a window
@@ -38,6 +39,7 @@ pub struct State {
     pub tag_layouts: HashMap<u8, String>,
     pub exec_path: String,
     pub rules: Vec<WindowRule>,
+    pub cursor_warp: CursorWarpMode,
 }
 
 impl State {
@@ -52,6 +54,7 @@ impl State {
             tag_layouts: HashMap::new(),
             exec_path: String::new(),
             rules: Vec::new(),
+            cursor_warp: CursorWarpMode::default(),
         }
     }
 

--- a/yashiki/src/effect.rs
+++ b/yashiki/src/effect.rs
@@ -8,6 +8,7 @@ pub enum Effect {
     FocusWindow {
         window_id: u32,
         pid: i32,
+        is_output_change: bool,
     },
     MoveWindowToPosition {
         window_id: u32,

--- a/yashiki/src/platform.rs
+++ b/yashiki/src/platform.rs
@@ -54,6 +54,7 @@ pub trait WindowManipulator {
     fn set_window_frame(&self, window_id: u32, pid: i32, x: i32, y: i32, width: u32, height: u32);
     fn close_window(&self, window_id: u32, pid: i32);
     fn exec_command(&self, command: &str, path: &str) -> Result<(), String>;
+    fn warp_cursor(&self, x: i32, y: i32);
 }
 
 /// macOS implementation of WindowManipulator
@@ -410,6 +411,18 @@ impl WindowManipulator for MacOSWindowManipulator {
 
     fn exec_command(&self, command: &str, path: &str) -> Result<(), String> {
         crate::macos::exec_command(command, path)
+    }
+
+    fn warp_cursor(&self, x: i32, y: i32) {
+        use core_graphics::display::CGWarpMouseCursorPosition;
+
+        let point = CGPoint::new(x as f64, y as f64);
+        let result = unsafe { CGWarpMouseCursorPosition(point) };
+        if result != 0 {
+            tracing::warn!("Failed to warp cursor to ({}, {}): error {}", x, y, result);
+        } else {
+            tracing::debug!("Warped cursor to ({}, {})", x, y);
+        }
     }
 }
 


### PR DESCRIPTION
  Add cursor warp feature similar to river's `set-cursor-warp`.

  ## Changes
  - Three modes: `disabled` (default), `on-output-change`, `on-focus-change`
  - New commands: `set-cursor-warp`, `get-cursor-warp`
  - Uses `CGWarpMouseCursorPosition` to move cursor to window center

  ## Usage
  ```sh
  yashiki set-cursor-warp on-focus-change

