### PR TITLE
feat: move outer-gap to core

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ cargo install --path yashiki-layout-byobu    # Accordion layout
 
    # Layout configuration
    yashiki layout-set-default tatami
-   yashiki layout-cmd --layout tatami set-outer-gap 10
-   yashiki layout-cmd --layout tatami set-inner-gap 10
+   yashiki set-outer-gap 10  # Gap between windows and screen edges (global)
+   yashiki layout-cmd --layout tatami set-inner-gap 10  # Gap between windows (layout-specific)
 
    # Cursor warp (mouse follows focus)
    yashiki set-cursor-warp on-focus-change
@@ -196,7 +196,7 @@ yashiki layout-set byobu              # Set layout for current tag
 yashiki layout-set --tags 4 byobu     # Set layout for tag 3
 yashiki layout-get                    # Get current layout
 yashiki layout-cmd set-main-ratio 0.6 # Send command to layout
-yashiki layout-cmd --layout tatami set-outer-gap 10  # Configure specific layout
+yashiki layout-cmd --layout tatami set-inner-gap 10  # Configure specific layout
 ```
 
 ### Utilities
@@ -218,6 +218,17 @@ yashiki set-cursor-warp disabled          # Don't move cursor (default)
 yashiki set-cursor-warp on-output-change  # Move cursor when switching displays
 yashiki set-cursor-warp on-focus-change   # Always move cursor to focused window
 yashiki get-cursor-warp                   # Get current mode
+```
+
+### Outer Gap
+
+Control the gap between windows and screen edges. Applied globally to all layouts and fullscreen windows.
+
+```sh
+yashiki set-outer-gap 10              # Set all sides to 10px
+yashiki set-outer-gap 10 20           # Set vertical=10px, horizontal=20px
+yashiki set-outer-gap 10 20 15 25     # Set top=10, right=20, bottom=15, left=25 (CSS-style)
+yashiki get-outer-gap                 # Get current outer gap
 ```
 
 ### State Streaming
@@ -305,7 +316,6 @@ Classic tiling layout with main area and stack.
 | `dec-main-count` | Remove window from main area |
 | `zoom [window_id]` | Move window to main area |
 | `set-inner-gap <px>` | Gap between windows |
-| `set-outer-gap <px>` | Gap from screen edges |
 
 ### byobu (accordion)
 

--- a/docs/layout-engine.md
+++ b/docs/layout-engine.md
@@ -21,8 +21,8 @@ Communication uses newline-delimited JSON. Each message is a single JSON object 
 enum LayoutMessage {
     // Request layout calculation
     Layout {
-        width: u32,      // Available width in pixels
-        height: u32,     // Available height in pixels
+        width: u32,      // Usable width in pixels (outer gap already subtracted)
+        height: u32,     // Usable height in pixels (outer gap already subtracted)
         windows: Vec<u32> // Window IDs to layout
     },
     // Send command to layout engine
@@ -32,6 +32,8 @@ enum LayoutMessage {
     }
 }
 ```
+
+> **Note:** The `width` and `height` values already have the outer gap subtracted by yashiki. Layout engines should position windows starting from (0, 0). Yashiki will add the outer gap offset when applying the geometries.
 
 **Example JSON:**
 ```json
@@ -108,7 +110,6 @@ Layout engines define their own commands. Examples from built-in engines:
 - `set-main-count <n>` - Set main window count
 - `zoom [window_id]` - Move window to main area
 - `set-inner-gap <px>` - Gap between windows
-- `set-outer-gap <all>` or `<v h>` or `<t r b l>` - Gap from edges
 
 **byobu (accordion):**
 - `set-padding <px>` - Stagger offset between windows
@@ -244,8 +245,11 @@ yashiki layout-set-default tatami
 # Use custom layout for specific tag (layout name only, not path)
 yashiki layout-set --tags 4 my-custom-layout
 
-# Configure layout parameters
-yashiki layout-cmd --layout tatami set-outer-gap 10
+# Configure outer gap (global, applied by daemon to all layouts)
+yashiki set-outer-gap 10
+
+# Configure inner gap (layout-specific)
+yashiki layout-cmd --layout tatami set-inner-gap 10
 ```
 
 ## Debugging Tips

--- a/yashiki-ipc/src/lib.rs
+++ b/yashiki-ipc/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod command;
 pub mod event;
 pub mod layout;
+pub mod outer_gap;
 
 pub use command::{
     BindingInfo, Command, CursorWarpMode, Direction, GlobPattern, OutputDirection, OutputInfo,
@@ -9,3 +10,4 @@ pub use command::{
 };
 pub use event::{EventFilter, StateEvent, SubscribeRequest};
 pub use layout::{LayoutMessage, LayoutResult, WindowGeometry};
+pub use outer_gap::OuterGap;

--- a/yashiki-ipc/src/outer_gap.rs
+++ b/yashiki-ipc/src/outer_gap.rs
@@ -1,0 +1,172 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OuterGap {
+    pub top: u32,
+    pub right: u32,
+    pub bottom: u32,
+    pub left: u32,
+}
+
+impl OuterGap {
+    pub fn all(value: u32) -> Self {
+        Self {
+            top: value,
+            right: value,
+            bottom: value,
+            left: value,
+        }
+    }
+
+    pub fn vertical_horizontal(vertical: u32, horizontal: u32) -> Self {
+        Self {
+            top: vertical,
+            right: horizontal,
+            bottom: vertical,
+            left: horizontal,
+        }
+    }
+
+    pub fn from_args(args: &[String]) -> Option<Self> {
+        match args.len() {
+            1 => args[0].parse().ok().map(Self::all),
+            2 => {
+                let v = args[0].parse().ok()?;
+                let h = args[1].parse().ok()?;
+                Some(Self::vertical_horizontal(v, h))
+            }
+            4 => {
+                let top = args[0].parse().ok()?;
+                let right = args[1].parse().ok()?;
+                let bottom = args[2].parse().ok()?;
+                let left = args[3].parse().ok()?;
+                Some(Self {
+                    top,
+                    right,
+                    bottom,
+                    left,
+                })
+            }
+            _ => None,
+        }
+    }
+
+    pub fn horizontal(&self) -> u32 {
+        self.left + self.right
+    }
+
+    pub fn vertical(&self) -> u32 {
+        self.top + self.bottom
+    }
+}
+
+impl std::fmt::Display for OuterGap {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{} {} {} {}",
+            self.top, self.right, self.bottom, self.left
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_outer_gap_all() {
+        let gap = OuterGap::all(10);
+        assert_eq!(gap.top, 10);
+        assert_eq!(gap.right, 10);
+        assert_eq!(gap.bottom, 10);
+        assert_eq!(gap.left, 10);
+    }
+
+    #[test]
+    fn test_outer_gap_vertical_horizontal() {
+        let gap = OuterGap::vertical_horizontal(10, 20);
+        assert_eq!(gap.top, 10);
+        assert_eq!(gap.bottom, 10);
+        assert_eq!(gap.right, 20);
+        assert_eq!(gap.left, 20);
+    }
+
+    #[test]
+    fn test_outer_gap_from_args_one_value() {
+        let gap = OuterGap::from_args(&["10".to_string()]).unwrap();
+        assert_eq!(gap.top, 10);
+        assert_eq!(gap.right, 10);
+        assert_eq!(gap.bottom, 10);
+        assert_eq!(gap.left, 10);
+    }
+
+    #[test]
+    fn test_outer_gap_from_args_two_values() {
+        let gap = OuterGap::from_args(&["10".to_string(), "20".to_string()]).unwrap();
+        assert_eq!(gap.top, 10);
+        assert_eq!(gap.bottom, 10);
+        assert_eq!(gap.right, 20);
+        assert_eq!(gap.left, 20);
+    }
+
+    #[test]
+    fn test_outer_gap_from_args_four_values() {
+        let gap = OuterGap::from_args(&[
+            "10".to_string(),
+            "20".to_string(),
+            "30".to_string(),
+            "40".to_string(),
+        ])
+        .unwrap();
+        assert_eq!(gap.top, 10);
+        assert_eq!(gap.right, 20);
+        assert_eq!(gap.bottom, 30);
+        assert_eq!(gap.left, 40);
+    }
+
+    #[test]
+    fn test_outer_gap_from_args_invalid() {
+        assert!(OuterGap::from_args(&[]).is_none());
+        assert!(
+            OuterGap::from_args(&["10".to_string(), "20".to_string(), "30".to_string()]).is_none()
+        );
+        assert!(OuterGap::from_args(&["abc".to_string()]).is_none());
+    }
+
+    #[test]
+    fn test_outer_gap_horizontal_vertical() {
+        let gap = OuterGap {
+            top: 10,
+            right: 20,
+            bottom: 30,
+            left: 40,
+        };
+        assert_eq!(gap.horizontal(), 60);
+        assert_eq!(gap.vertical(), 40);
+    }
+
+    #[test]
+    fn test_outer_gap_display() {
+        let gap = OuterGap {
+            top: 10,
+            right: 20,
+            bottom: 30,
+            left: 40,
+        };
+        assert_eq!(format!("{}", gap), "10 20 30 40");
+    }
+
+    #[test]
+    fn test_outer_gap_serialization() {
+        let gap = OuterGap::all(10);
+        let json = serde_json::to_string(&gap).unwrap();
+        assert!(json.contains("\"top\":10"));
+        assert!(json.contains("\"right\":10"));
+        assert!(json.contains("\"bottom\":10"));
+        assert!(json.contains("\"left\":10"));
+
+        let deserialized: OuterGap = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized, gap);
+    }
+}

--- a/yashiki/src/core/state.rs
+++ b/yashiki/src/core/state.rs
@@ -5,7 +5,7 @@ use crate::macos::DisplayId;
 use crate::platform::WindowSystem;
 use std::collections::{HashMap, HashSet};
 use yashiki_ipc::{
-    CursorWarpMode, Direction, OutputDirection, OutputSpecifier, RuleAction, RuleMatcher,
+    CursorWarpMode, Direction, OuterGap, OutputDirection, OutputSpecifier, RuleAction, RuleMatcher,
     WindowRule,
 };
 
@@ -49,6 +49,7 @@ pub struct State {
     pub exec_path: String,
     pub rules: Vec<WindowRule>,
     pub cursor_warp: CursorWarpMode,
+    pub outer_gap: OuterGap,
 }
 
 impl State {
@@ -64,6 +65,7 @@ impl State {
             exec_path: String::new(),
             rules: Vec::new(),
             cursor_warp: CursorWarpMode::default(),
+            outer_gap: OuterGap::default(),
         }
     }
 


### PR DESCRIPTION
  Outer gap is now managed by the yashiki daemon instead of layout engines.

  - Add `set-outer-gap` / `get-outer-gap` commands (CSS-style: 1/2/4 values)
  - Apply outer gap uniformly to all layouts and fullscreen windows
  - Remove outer-gap from tatami (inner-gap remains layout-specific)

