### PR TITLE
fix: detect windows from apps running without windows at startup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -319,6 +319,7 @@ yashiki bind alt-s exec-or-focus --app-name Safari "open -a Safari"
 - **macos/display.rs** - CGWindowList window enumeration, display info
   - `get_on_screen_windows()` (includes bundle_id), `get_all_displays()` (uses NSScreen visibleFrame)
 - **macos/observer.rs** - AXObserver for window events
+  - `ObserverManager` with `add_observer()`, `remove_observer()`, `has_observer()`
 - **macos/workspace.rs** - NSWorkspace app launch/terminate notifications, display change notifications, `activate_application()`, `get_frontmost_app_pid()`, `get_bundle_id_for_pid()`, `exec_command()`
 - **macos/hotkey.rs** - CGEventTap global hotkeys
   - `HotkeyManager` with dynamic bind/unbind
@@ -348,6 +349,7 @@ yashiki bind alt-s exec-or-focus --app-name Safari "open -a Safari"
   - CFRunLoopSource for immediate IPC command processing
   - CFRunLoopSource for immediate hotkey command processing
   - CFRunLoop timer (50ms) for workspace events, observer events, and deferred hotkey tap updates
+  - Periodic window scanning for apps without observers (e.g., Finder with only desktop at startup)
   - Auto-retile on window add/remove
   - Runs init script at startup
   - Effect pattern: `process_command()` (pure) + `execute_effects()` (side effects)

--- a/yashiki/src/macos/observer.rs
+++ b/yashiki/src/macos/observer.rs
@@ -99,6 +99,10 @@ impl ObserverManager {
             tracing::debug!("Removed observer for pid {}", pid);
         }
     }
+
+    pub fn has_observer(&self, pid: i32) -> bool {
+        self.observers.contains_key(&pid)
+    }
 }
 
 extern "C" fn observer_callback(


### PR DESCRIPTION
  Fix Finder windows not being detected when yashiki starts with Finder showing only desktop.

  ## Problem
  Apps running without windows at startup (e.g., Finder with only desktop) were not getting AXObservers added, so windows opened later were never detected.

  ## Solution
  Add periodic window scanning in timer callback to detect new windows from apps without observers, then add observers for those apps.

  ## Changes
  - Add `has_observer()` method to `ObserverManager`
  - Add window scanning logic in timer callback (runs every 50ms, lightweight)

