### PR TITLE
feat: add --all and --debug option to list-windows

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -211,7 +211,10 @@ yashiki layout-cmd --layout tatami set-inner-gap 10  # Send command to specific 
 yashiki layout-cmd inc-main-count       # Increase main window count
 yashiki layout-cmd zoom                 # Move focused window to main area (tatami)
 yashiki layout-cmd zoom 123             # Move specific window to main area (tatami)
-yashiki list-windows              # List all windows
+yashiki list-windows              # List managed windows
+yashiki list-windows --all        # Include ignored windows (popups, tooltips)
+yashiki list-windows --debug      # Show debug info (ax_id, subrole, window_level, buttons)
+yashiki list-windows --all --debug  # Both options
 yashiki list-outputs              # List all displays/outputs
 yashiki get-state                 # Get current state
 yashiki exec "open -a Safari"     # Execute shell command

--- a/README.md
+++ b/README.md
@@ -210,7 +210,9 @@ yashiki layout-cmd --layout tatami set-inner-gap 10  # Configure specific layout
 ### Utilities
 
 ```sh
-yashiki list-windows             # List all windows
+yashiki list-windows             # List managed windows
+yashiki list-windows --all       # Include ignored windows (popups, tooltips)
+yashiki list-windows --debug     # Show debug info (ax_id, subrole, window_level, buttons)
 yashiki list-outputs             # List all displays
 yashiki get-state                # Get current state
 yashiki exec "open -a Safari"    # Execute command

--- a/docs/window-rules.md
+++ b/docs/window-rules.md
@@ -95,8 +95,8 @@ yashiki rule-add --close-button none ignore
 # Ghostty Quick Terminal: fullscreen disabled, close enabled
 yashiki rule-add --app-id com.mitchellh.ghostty --fullscreen-button disabled ignore
 
-# Firefox PiP: minimize button is disabled
-yashiki rule-add --app-id org.mozilla.firefox --minimize-button disabled float
+# Firefox PiP: use window-level floating
+yashiki rule-add --app-id org.mozilla.firefox --window-level floating float
 ```
 
 ### Combining Matchers
@@ -266,7 +266,32 @@ Using `>>` (append) allows inspecting multiple windows in sequence. Clear the fi
 
 ### Debugging Window Discovery
 
-To see what windows yashiki discovers and their attributes, run with debug logging:
+#### Using list-windows with Debug Info
+
+The easiest way to inspect window attributes is using `list-windows --debug`:
+
+```sh
+# Show managed windows with debug info (ax_id, subrole, window_level, buttons)
+yashiki list-windows --debug
+
+# Show ALL windows including ignored ones (popups, tooltips)
+yashiki list-windows --all
+
+# Combine both to see everything
+yashiki list-windows --all --debug
+```
+
+This shows output like:
+```
+12345: Firefox (org.mozilla.firefox) - Menu [tags=1, 200x50 @ (100,200)] [ignored]
+  ax_id=None, subrole=AXUnknown, level=normal, close=enabled, fullscreen=enabled, minimize=enabled, zoom=enabled
+```
+
+The `--all` flag is useful for finding ignored windows (like Firefox dropdowns) that you might want to create rules for.
+
+#### Using Debug Logging
+
+For more detailed logs during window discovery, run with debug logging:
 
 ```sh
 RUST_LOG=yashiki=debug yashiki start

--- a/docs/workarounds.md
+++ b/docs/workarounds.md
@@ -38,19 +38,16 @@ yashiki rule-add --app-name "Bartender 4" ignore
 
 ## Firefox
 
-Firefox creates temporary popup windows (dropdowns, autocomplete, etc.) that can cause flickering during window tiling. These popups have inconsistent `AXSubrole` values that sometimes bypass ignore rules.
+Firefox creates temporary popup windows (dropdowns, autocomplete, etc.) that can cause flickering during window tiling.
 
-**Workaround:**
+**Recommended rules:**
 
 ```sh
-# Ignore popup windows with AXUnknown subrole
+# Ignore popup windows with AXUnknown subrole (dropdowns, autocomplete, etc.)
 yashiki rule-add --app-id org.mozilla.firefox --subrole AXUnknown ignore
 
-# Float windows with empty titles (PiP, etc.)
-yashiki rule-add --app-id org.mozilla.firefox --title "" float
-
-# But keep normal windows with empty titles in tiling
-yashiki rule-add --app-id org.mozilla.firefox --title "" --subrole AXStandardWindow no-float
+# Float PiP (Picture-in-Picture) and other floating-level windows
+yashiki rule-add --app-id org.mozilla.firefox --window-level floating float
 ```
 
 Add these rules to your `~/.config/yashiki/init` file.

--- a/yashiki-ipc/src/command.rs
+++ b/yashiki-ipc/src/command.rs
@@ -12,6 +12,14 @@ pub enum CursorWarpMode {
     OnFocusChange,
 }
 
+/// Window status - indicates whether a window is managed or ignored
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WindowStatus {
+    Managed,
+    Ignored,
+}
+
 /// Button state matcher for window rules
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -209,6 +217,7 @@ pub struct RuleMatcher {
 pub struct ExtendedWindowAttributes {
     pub ax_id: Option<String>,
     pub subrole: Option<String>,
+    pub title: Option<String>,
     pub window_level: i32,
     pub close_button: ButtonInfo,
     pub fullscreen_button: ButtonInfo,
@@ -615,7 +624,12 @@ pub enum Command {
     ListBindings,
 
     // Queries
-    ListWindows,
+    ListWindows {
+        #[serde(default)]
+        all: bool,
+        #[serde(default)]
+        debug: bool,
+    },
     ListOutputs,
     GetState,
     FocusedWindow,
@@ -743,6 +757,24 @@ pub struct WindowInfo {
     pub is_focused: bool,
     pub is_floating: bool,
     pub is_fullscreen: bool,
+    // Optional status field (present when --all is used)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<WindowStatus>,
+    // Debug fields (present when --debug is used)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ax_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subrole: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub window_level: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub close_button: Option<ButtonInfo>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fullscreen_button: Option<ButtonInfo>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub minimize_button: Option<ButtonInfo>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub zoom_button: Option<ButtonInfo>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -918,6 +950,14 @@ mod tests {
                 is_focused: true,
                 is_floating: false,
                 is_fullscreen: false,
+                status: None,
+                ax_id: None,
+                subrole: None,
+                window_level: None,
+                close_button: None,
+                fullscreen_button: None,
+                minimize_button: None,
+                zoom_button: None,
             }],
         };
         let json = serde_json::to_string(&resp).unwrap();
@@ -1596,6 +1636,14 @@ mod tests {
                 is_focused: true,
                 is_floating: false,
                 is_fullscreen: false,
+                status: None,
+                ax_id: None,
+                subrole: None,
+                window_level: None,
+                close_button: None,
+                fullscreen_button: None,
+                minimize_button: None,
+                zoom_button: None,
             }],
         };
         let json = serde_json::to_string(&resp).unwrap();

--- a/yashiki-ipc/src/event.rs
+++ b/yashiki-ipc/src/event.rs
@@ -179,6 +179,14 @@ mod tests {
                 is_focused: false,
                 is_floating: false,
                 is_fullscreen: false,
+                status: None,
+                ax_id: None,
+                subrole: None,
+                window_level: None,
+                close_button: None,
+                fullscreen_button: None,
+                minimize_button: None,
+                zoom_button: None,
             }
         }));
         assert!(window_filter.matches(&StateEvent::WindowDestroyed { window_id: 1 }));

--- a/yashiki-ipc/src/lib.rs
+++ b/yashiki-ipc/src/lib.rs
@@ -7,7 +7,7 @@ pub use command::{
     BindingInfo, ButtonInfo, ButtonState, Command, CursorWarpMode, Direction,
     ExtendedWindowAttributes, GlobPattern, OutputDirection, OutputInfo, OutputSpecifier, Response,
     RuleAction, RuleInfo, RuleMatcher, StateInfo, WindowInfo, WindowLevel, WindowLevelName,
-    WindowLevelOther, WindowRule,
+    WindowLevelOther, WindowRule, WindowStatus,
 };
 pub use event::{EventFilter, StateEvent, SubscribeRequest};
 pub use layout::{LayoutMessage, LayoutResult, WindowGeometry};

--- a/yashiki/src/core/window.rs
+++ b/yashiki/src/core/window.rs
@@ -72,6 +72,7 @@ impl Window {
         yashiki_ipc::ExtendedWindowAttributes {
             ax_id: self.ax_id.clone(),
             subrole: self.subrole.clone(),
+            title: Some(self.title.clone()),
             window_level: self.window_level,
             close_button: self.close_button.clone(),
             fullscreen_button: self.fullscreen_button.clone(),

--- a/yashiki/src/event_emitter.rs
+++ b/yashiki/src/event_emitter.rs
@@ -127,6 +127,15 @@ pub fn window_to_info(window: &Window, focused: Option<u32>) -> WindowInfo {
         is_focused: focused == Some(window.id),
         is_floating: window.is_floating,
         is_fullscreen: window.is_fullscreen,
+        // Debug fields not included in event streaming
+        status: None,
+        ax_id: None,
+        subrole: None,
+        window_level: None,
+        close_button: None,
+        fullscreen_button: None,
+        minimize_button: None,
+        zoom_button: None,
     }
 }
 


### PR DESCRIPTION
  - Remove title from `list-windows` default output (shown only with `--debug`)
  - Fetch window titles from AXUIElement's AXTitle instead of CGWindowList's kCGWindowName
  - Update Firefox workaround docs

