### PR TITLE
fix: apply rules immediately on rule-add after init completed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,8 @@ macOS tiling window manager written in Rust.
   2. Run `jj status` to confirm current workspace state
 - All file edits must target files under the workspace root path
 - Update only this CLAUDE.md, not the root one
+- **jj write operations (commit, describe, new, etc.) are done by the user, not Claude**
+  - For PRs: output title and description text, let the user handle jj/git operations
 
 ## Project Structure
 

--- a/yashiki/src/core/state.rs
+++ b/yashiki/src/core/state.rs
@@ -51,6 +51,7 @@ pub struct State {
     pub rules: Vec<WindowRule>,
     pub cursor_warp: CursorWarpMode,
     pub outer_gap: OuterGap,
+    pub init_completed: bool,
 }
 
 impl State {
@@ -67,6 +68,7 @@ impl State {
             rules: Vec::new(),
             cursor_warp: CursorWarpMode::default(),
             outer_gap: OuterGap::default(),
+            init_completed: false,
         }
     }
 


### PR DESCRIPTION
  Fix rule-add command to apply rules immediately after init is completed.

  - Add `init_completed` flag to `State`
  - Set flag to true on ApplyRules command
  - Send ApplyRules even when init script is missing or fails
  - Apply rules immediately on RuleAdd when init is completed

