### PR TITLE
feat: support "none" matcher for --ax-id and --subrole

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -241,6 +241,7 @@ yashiki rule-add --window-level floating float    # Float utility panels (level 
 yashiki rule-add --fullscreen-button none float   # Float windows without fullscreen button
 yashiki rule-add --close-button none ignore       # Ignore windows without close button (popups)
 yashiki rule-add --app-id com.mitchellh.ghostty --fullscreen-button disabled ignore  # Ghostty Quick Terminal
+yashiki rule-add --app-id com.microsoft.Outlook --ax-id none --subrole none ignore  # Outlook invisible windows
 yashiki rule-del --app-name Finder float          # Remove a rule
 yashiki list-rules                # List all rules
 yashiki set-cursor-warp disabled          # Disable cursor warp (default)
@@ -589,7 +590,9 @@ Focus involves: `activate_application(pid)` then `AXUIElement.raise()`
   - `--window-level` (CGWindowLevel: normal, floating, modal, utility, popup, other, or numeric)
   - `--close-button`, `--fullscreen-button`, `--minimize-button`, `--zoom-button` (button states: exists, none, enabled, disabled)
 - For subrole matching, "AX" prefix is optional: `--subrole Dialog` matches `AXDialog`
-- Specificity calculation: exact match > prefix/suffix > contains > wildcard; button matchers add fixed specificity
+- For `--ax-id` and `--subrole`, special pattern "none" matches windows where the attribute is absent (None)
+  - Example: `--ax-id none --subrole none` matches windows with no AXIdentifier and no AXSubrole
+- Specificity calculation: exact match > prefix/suffix > contains > "none" (1) > wildcard (0); button matchers add fixed specificity
 - Multiple rules can match; each action type uses "first match wins"
 - Floating windows excluded from tiling (`visible_windows_on_display()` filter)
 - Rules applied in `timer_callback` after `sync_pid()` returns new window IDs
@@ -655,6 +658,9 @@ yashiki rule-add --window-level floating float
 
   # Ignore only Firefox popup windows
   yashiki rule-add --app-id org.mozilla.firefox --subrole AXUnknown ignore
+
+  # Ignore Outlook invisible windows (no AXIdentifier, no AXSubrole)
+  yashiki rule-add --app-id com.microsoft.Outlook --ax-id none --subrole none ignore
   ```
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ yashiki rule-add --app-id com.mitchellh.ghostty --fullscreen-button disabled ign
 # Ignore windows completely (never manage - useful for popups/dropdowns)
 yashiki rule-add --subrole AXUnknown ignore  # Ignore all popup windows
 yashiki rule-add --app-id org.mozilla.firefox --subrole AXUnknown ignore  # Firefox popups only
+yashiki rule-add --app-id com.microsoft.Outlook --ax-id none --subrole none ignore  # Outlook invisible windows
 
 # Combined matching (more specific)
 yashiki rule-add --app-name Safari --title "*Preferences*" float

--- a/docs/window-rules.md
+++ b/docs/window-rules.md
@@ -41,8 +41,8 @@ Window rules let you automatically configure window properties based on various 
 | `--app-name` | Application name | `Safari`, `*Chrome*` |
 | `--app-id` | Bundle identifier | `com.apple.Safari`, `com.google.*` |
 | `--title` | Window title | `*Preferences*`, `*Dialog*` |
-| `--ax-id` | AXIdentifier attribute | `com.mitchellh.ghostty.quickTerminal` |
-| `--subrole` | AXSubrole attribute | `Dialog`, `FloatingWindow` |
+| `--ax-id` | AXIdentifier attribute | `com.mitchellh.ghostty.quickTerminal`, `none` |
+| `--subrole` | AXSubrole attribute | `Dialog`, `FloatingWindow`, `none` |
 | `--window-level` | Window level | `normal`, `floating`, `other`, `8` |
 | `--close-button` | Close button state | `exists`, `none`, `enabled`, `disabled` |
 | `--fullscreen-button` | Fullscreen button state | `exists`, `none`, `enabled`, `disabled` |
@@ -50,6 +50,13 @@ Window rules let you automatically configure window properties based on various 
 | `--zoom-button` | Zoom button state | `exists`, `none`, `enabled`, `disabled` |
 
 Glob patterns (`*` for any characters) are supported for `--app-name`, `--app-id`, `--title`, `--ax-id`, and `--subrole`.
+
+For `--ax-id` and `--subrole`, the special pattern `none` matches windows where the attribute is absent (not set). This is useful for matching windows that lack these accessibility attributes:
+
+```sh
+# Match windows with no AXIdentifier and no AXSubrole (e.g., Outlook invisible windows)
+yashiki rule-add --app-id com.microsoft.Outlook --ax-id none --subrole none ignore
+```
 
 ### Window Level Matcher
 
@@ -345,6 +352,9 @@ yashiki rule-add --subrole AXUnknown ignore
 # Ignore only Firefox popup windows
 yashiki rule-add --app-id org.mozilla.firefox --subrole AXUnknown ignore
 
+# Ignore windows with no AX attributes (e.g., Outlook invisible windows)
+yashiki rule-add --app-id com.microsoft.Outlook --ax-id none --subrole none ignore
+
 # Find the AXIdentifier using Accessibility Inspector or the script above
 ```
 
@@ -409,6 +419,12 @@ yashiki rule-add --app-id "com.google.*" output 2
 
 Not all windows have an AXIdentifier. If Accessibility Inspector shows "(null)" or empty:
 
-1. Try using `--subrole` instead
-2. Use `--app-id` combined with `--title` for more specific matching
-3. Some windows may not be distinguishable by AX attributes
+1. Use `--ax-id none` to match windows without an AXIdentifier
+2. Try using `--subrole` instead (or `--subrole none` if subrole is also absent)
+3. Use `--app-id` combined with `--title` for more specific matching
+4. Some windows may not be distinguishable by AX attributes
+
+Example for windows with no AX attributes:
+```sh
+yashiki rule-add --app-id com.microsoft.Outlook --ax-id none --subrole none ignore
+```

--- a/docs/workarounds.md
+++ b/docs/workarounds.md
@@ -8,6 +8,7 @@ This page documents known issues with specific applications and their workaround
 - [Contexts](#contexts)
 - [Bartender](#bartender)
 - [Firefox](#firefox)
+- [Microsoft Outlook](#microsoft-outlook)
 - [Ghostty](#ghostty)
 - [IINA](#iina)
 - [Generic Popup/Palette Windows](#generic-popuppalette-windows)
@@ -52,6 +53,22 @@ yashiki rule-add --app-id org.mozilla.firefox --window-level floating float
 ```
 
 Add these rules to your `~/.config/yashiki/init` file.
+
+## Microsoft Outlook
+
+Outlook creates various windows that can interfere with window management.
+
+**Recommended rules:**
+
+```sh
+# Ignore popup windows with AXUnknown subrole (dropdowns, menus, etc.)
+yashiki rule-add --app-id com.microsoft.Outlook --subrole AXUnknown ignore
+
+# Ignore invisible windows with no AX attributes
+yashiki rule-add --app-id com.microsoft.Outlook --ax-id none --subrole none ignore
+```
+
+The first rule is similar to Firefox - it ignores popup menus and dropdowns. The second rule ignores mysterious invisible windows that Outlook creates without any accessibility attributes.
 
 ## Ghostty
 

--- a/yashiki/src/main.rs
+++ b/yashiki/src/main.rs
@@ -355,10 +355,10 @@ struct RuleAddCmd {
     /// window title pattern (glob)
     #[argh(option)]
     title: Option<String>,
-    /// AXIdentifier pattern (glob, e.g., "com.mitchellh.ghostty.quickTerminal")
+    /// AXIdentifier pattern (glob, "none" matches absent)
     #[argh(option)]
     ax_id: Option<String>,
-    /// AXSubrole pattern (glob, AX prefix optional, e.g., "Dialog", "FloatingWindow")
+    /// AXSubrole pattern (glob, AX prefix optional, "none" matches absent)
     #[argh(option)]
     subrole: Option<String>,
     /// window level (normal, floating, modal, utility, popup, other, or numeric)
@@ -394,10 +394,10 @@ struct RuleDelCmd {
     /// window title pattern (glob)
     #[argh(option)]
     title: Option<String>,
-    /// AXIdentifier pattern (glob)
+    /// AXIdentifier pattern (glob, "none" matches absent)
     #[argh(option)]
     ax_id: Option<String>,
-    /// AXSubrole pattern (glob, AX prefix optional)
+    /// AXSubrole pattern (glob, AX prefix optional, "none" matches absent)
     #[argh(option)]
     subrole: Option<String>,
     /// window level (normal, floating, modal, utility, popup, other, or numeric)


### PR DESCRIPTION
  Allow --ax-id none and --subrole none in window rules to match windows where the attribute is absent.

  yashiki rule-add --app-id com.microsoft.Outlook --ax-id none --subrole none ignore

