### PR TITLE
fix: improve handling of windows not in state and hidden window movement

### DIFF
--- a/yashiki/src/app.rs
+++ b/yashiki/src/app.rs
@@ -141,7 +141,8 @@ impl App {
         let window_system = MacOSWindowSystem;
         let mut state = State::new();
         state.config.exec_path = build_initial_exec_path();
-        state.sync_all(&window_system);
+        // Initial sync has no hidden windows, so rehide_moves is always empty
+        let _ = state.sync_all(&window_system);
 
         // Create layout engine manager (lazy spawning)
         let mut layout_engine_manager = LayoutEngineManager::new();

--- a/yashiki/src/core/state/display.rs
+++ b/yashiki/src/core/state/display.rs
@@ -25,7 +25,7 @@ pub fn handle_display_change<W: WindowSystem>(state: &mut State, ws: &W) -> Disp
             .map(|(id, w)| (*id, w.display_id))
             .collect();
 
-        sync_all(state, ws);
+        let rehide_moves = sync_all(state, ws);
 
         let mut stolen_window_displays: HashSet<DisplayId> = HashSet::new();
         for (window_id, original_display_id) in &visible_window_displays {
@@ -56,7 +56,7 @@ pub fn handle_display_change<W: WindowSystem>(state: &mut State, ws: &W) -> Disp
         displays_to_retile.extend(stolen_window_displays);
 
         return DisplayChangeResult {
-            window_moves: vec![],
+            window_moves: rehide_moves,
             displays_to_retile,
             added,
             removed: vec![],
@@ -111,7 +111,7 @@ pub fn handle_display_change<W: WindowSystem>(state: &mut State, ws: &W) -> Disp
         state.displays.remove(id);
     }
 
-    sync_all(state, ws);
+    let rehide_moves = sync_all(state, ws);
 
     let added: Vec<_> = state
         .displays
@@ -124,6 +124,7 @@ pub fn handle_display_change<W: WindowSystem>(state: &mut State, ws: &W) -> Disp
         let moves = compute_layout_changes_for_display(state, *display_id);
         window_moves.extend(moves);
     }
+    window_moves.extend(rehide_moves);
 
     let displays_to_retile: Vec<_> = affected_displays.into_iter().collect();
 

--- a/yashiki/src/core/state/mod.rs
+++ b/yashiki/src/core/state/mod.rs
@@ -206,7 +206,7 @@ impl State {
 
     // Sync operations - delegated to state/sync.rs
 
-    pub fn sync_all<W: WindowSystem>(&mut self, ws: &W) {
+    pub fn sync_all<W: WindowSystem>(&mut self, ws: &W) -> Vec<WindowMove> {
         sync_all(self, ws)
     }
 


### PR DESCRIPTION
  - Fix managing windows that are not tracked in the state
  - Detect when macOS moves hidden windows from their hide position and automatically re-hide them
