### PR TITLE
fix: Filter out Control Center windows early in sync process

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,12 +201,30 @@ Each group sorted alphabetically, blank lines between groups.
 
 ## Workflow
 
-- Present plan and wait for approval before implementing
-- **Review requests = report only, NEVER auto-fix**
-  - When asked to "review", "check", or "verify" code: report findings, do NOT modify code
-  - Wait for explicit approval before making any changes
-  - This applies even when bugs or issues are found during review
-- Run `cargo fmt --all` at the end of each task
+### ⚠️ CRITICAL: Never modify code without explicit approval
+
+**DO NOT edit any source code (*.rs, etc.) until the user explicitly approves.**
+
+Examples of what is NOT approval:
+- Discussing a plan or approach
+- Answering questions about implementation details
+- User saying the approach "sounds good" or "makes sense"
+
+**You MUST explicitly ask "Should I implement this?" and wait for clear confirmation before editing any code.**
+
+**Workflow:**
+1. Analyze the problem and present a plan
+2. Ask "Should I implement this?" (or similar)
+3. Wait for explicit approval from user
+4. Only then use Edit/Write tools on source code
+5. Run `cargo fmt --all` at the end of each task
+
+**Review requests = report only, NEVER auto-fix:**
+- When asked to "review", "check", or "verify" code: report findings, do NOT modify code
+- Wait for explicit approval before making any changes
+- This applies even when bugs or issues are found during review
+
+**Documentation updates:**
 - Update docs when adding/changing features: README.md, CLAUDE.md, docs/*.md
 
 ## Design Decisions

--- a/yashiki/src/core/state/sync.rs
+++ b/yashiki/src/core/state/sync.rs
@@ -329,6 +329,12 @@ pub fn try_create_window<W: WindowSystem>(
     let app_name = &info.owner_name;
     let app_id = info.bundle_id.as_deref();
 
+    // Filter Control Center early - system UI that users never need to manage,
+    // and it creates many transient windows that slow down processing
+    if app_id == Some("com.apple.controlcenter") {
+        return None;
+    }
+
     let ext = ws.get_extended_attributes(info.window_id, info.pid, info.layer);
 
     let title = ext


### PR DESCRIPTION

  Skip Control Center (com.apple.controlcenter) windows before calling get_extended_attributes() to avoid unnecessary Accessibility API
  calls and reduce log noise. Control Center creates many transient system UI windows that users never need to manage.
