### PR TITLE
fix!: use per-display hide position to prevent window disappearance during cross-display fullscreen

### DIFF
--- a/yashiki/src/core/state/rules.rs
+++ b/yashiki/src/core/state/rules.rs
@@ -185,7 +185,7 @@ fn compute_hide_for_window(state: &mut State, window_id: WindowId) -> Option<Win
     }
 
     let visible_tags = state.displays.get(&display_id)?.visible_tags;
-    let (hide_x, hide_y) = super::layout::compute_global_hide_position(state);
+    let (hide_x, hide_y) = super::layout::compute_hide_position_for_display(state, display_id);
 
     let should_be_visible = window_tags.intersects(visible_tags);
 


### PR DESCRIPTION
  - Windows on each display are now hidden to their own display's corner instead of a global position
  - Prevents main display windows from becoming inaccessible when sub display enters fullscreen (e.g., Firefox YouTube
  fullscreen creates a new macOS Space)

  ## Changes
  - Add `compute_hide_position_for_display()` that selects a safe corner for each display
  - Update all hide position usages in layout.rs, sync.rs, rules.rs

