### PR TITLE
fix: track orphaned windows during sleep/wake to restore them to original display

### DIFF
--- a/yashiki/src/core/window.rs
+++ b/yashiki/src/core/window.rs
@@ -25,6 +25,10 @@ pub struct Window {
     pub saved_frame: Option<Rect>,
     pub is_floating: bool,
     pub is_fullscreen: bool,
+    /// Display ID that this window was orphaned from during display disconnection.
+    /// Some(display_id): Window was orphaned due to display removal (remembers original display)
+    /// None: Window is on its intended display
+    pub orphaned_from: Option<DisplayId>,
 }
 
 impl Window {
@@ -48,6 +52,7 @@ impl Window {
             saved_frame: None,
             is_floating: false,
             is_fullscreen: false,
+            orphaned_from: None,
         }
     }
 

--- a/yashiki/src/event_emitter.rs
+++ b/yashiki/src/event_emitter.rs
@@ -184,6 +184,7 @@ mod tests {
             saved_frame: None,
             is_floating: false,
             is_fullscreen: false,
+            orphaned_from: None,
         }
     }
 


### PR DESCRIPTION
  - When displays disconnect during sleep, windows are moved to fallback display and `orphaned_from` records the original
  display ID
  - When the original display returns on wake, windows are automatically restored
  - Orphan state is cleared when user explicitly moves window via `output-send`
