### PR TITLE
fix: use per-window hide position calculation with window size offset

### DIFF
--- a/yashiki/src/core/state/layout.rs
+++ b/yashiki/src/core/state/layout.rs
@@ -1,7 +1,79 @@
+use super::super::window::Rect;
 use super::super::{Window, WindowId};
 use crate::macos::DisplayId;
 
 use super::super::state::{State, WindowMove};
+
+/// Check if two ranges overlap (exclusive end)
+fn ranges_overlap(a_start: i32, a_end: i32, b_start: i32, b_end: i32) -> bool {
+    a_start < b_end && b_start < a_end
+}
+
+/// Check if there's a display immediately to the right that shares vertical range
+fn has_right_adjacent_display(state: &State, display_id: DisplayId, frame: &Rect) -> bool {
+    let right_edge = frame.x + frame.width as i32;
+    state.displays.values().any(|other| {
+        if other.id == display_id {
+            return false;
+        }
+        other.frame.x == right_edge
+            && ranges_overlap(
+                frame.y,
+                frame.y + frame.height as i32,
+                other.frame.y,
+                other.frame.y + other.frame.height as i32,
+            )
+    })
+}
+
+/// Check if there's a display immediately to the left that shares vertical range
+fn has_left_adjacent_display(state: &State, display_id: DisplayId, frame: &Rect) -> bool {
+    state.displays.values().any(|other| {
+        if other.id == display_id {
+            return false;
+        }
+        other.frame.x + other.frame.width as i32 == frame.x
+            && ranges_overlap(
+                frame.y,
+                frame.y + frame.height as i32,
+                other.frame.y,
+                other.frame.y + other.frame.height as i32,
+            )
+    })
+}
+
+/// Check if there's a display immediately below that shares horizontal range
+fn has_bottom_adjacent_display(state: &State, display_id: DisplayId, frame: &Rect) -> bool {
+    let bottom_edge = frame.y + frame.height as i32;
+    state.displays.values().any(|other| {
+        if other.id == display_id {
+            return false;
+        }
+        other.frame.y == bottom_edge
+            && ranges_overlap(
+                frame.x,
+                frame.x + frame.width as i32,
+                other.frame.x,
+                other.frame.x + other.frame.width as i32,
+            )
+    })
+}
+
+/// Check if there's a display immediately above that shares horizontal range
+fn has_top_adjacent_display(state: &State, display_id: DisplayId, frame: &Rect) -> bool {
+    state.displays.values().any(|other| {
+        if other.id == display_id {
+            return false;
+        }
+        other.frame.y + other.frame.height as i32 == frame.y
+            && ranges_overlap(
+                frame.x,
+                frame.x + frame.width as i32,
+                other.frame.x,
+                other.frame.x + other.frame.width as i32,
+            )
+    })
+}
 
 pub fn compute_global_hide_position(state: &State) -> (i32, i32) {
     let mut max_x = 0i32;
@@ -18,44 +90,77 @@ pub fn compute_global_hide_position(state: &State) -> (i32, i32) {
 }
 
 /// Compute per-display hide position to avoid cross-display interference.
-/// Selects a corner that doesn't overlap with other displays.
+/// Selects a corner where the window body won't extend into adjacent displays.
 /// Priority: bottom-right → bottom-left → top-right → top-left
-pub fn compute_hide_position_for_display(state: &State, display_id: DisplayId) -> (i32, i32) {
+///
+/// macOS window position is the top-left corner, and the window body extends
+/// right and down from that point. To hide a window at a corner while keeping
+/// 1px visible (required by macOS), we must offset by window dimensions:
+/// - bottom-right: no offset needed (window extends right & down into void)
+/// - bottom-left: offset x by -(window_width - 1) so window extends left
+/// - top-right: offset y by -(window_height - 1) so window extends up
+/// - top-left: offset both x and y
+///
+/// A corner is unsafe if there's an adjacent display in the direction the window extends.
+pub fn compute_hide_position_for_display(
+    state: &State,
+    display_id: DisplayId,
+    window_width: u32,
+    window_height: u32,
+) -> (i32, i32) {
     let Some(display) = state.displays.get(&display_id) else {
         return compute_global_hide_position(state);
     };
 
     let frame = &display.frame;
 
-    // 4 corner candidates (keep 1px inside the screen)
+    // Pre-compute adjacency for each direction
+    let has_right = has_right_adjacent_display(state, display_id, frame);
+    let has_left = has_left_adjacent_display(state, display_id, frame);
+    let has_bottom = has_bottom_adjacent_display(state, display_id, frame);
+    let has_top = has_top_adjacent_display(state, display_id, frame);
+
+    // 4 corner candidates with their safety conditions
+    // (corner_x, corner_y, is_unsafe)
+    // Position is calculated so that 1px of window remains visible at the corner
     let corners = [
+        // bottom-right: window at (display_right - 1, display_bottom - 1)
+        // Window extends right & down into void, 1px visible at bottom-right corner
         (
             frame.x + frame.width as i32 - 1,
             frame.y + frame.height as i32 - 1,
-        ), // bottom-right
-        (frame.x, frame.y + frame.height as i32 - 1), // bottom-left
-        (frame.x + frame.width as i32 - 1, frame.y),  // top-right
-        (frame.x, frame.y),                           // top-left
+            has_right || has_bottom,
+        ),
+        // bottom-left: window at (display_left - window_width + 1, display_bottom - 1)
+        // Window extends right (into display) but only 1px visible, rest extends left
+        (
+            frame.x - window_width as i32 + 1,
+            frame.y + frame.height as i32 - 1,
+            has_left || has_bottom,
+        ),
+        // top-right: window at (display_right - 1, display_top - window_height + 1)
+        // Window extends down (into display) but only 1px visible, rest extends up
+        (
+            frame.x + frame.width as i32 - 1,
+            frame.y - window_height as i32 + 1,
+            has_right || has_top,
+        ),
+        // top-left: offset both x and y
+        (
+            frame.x - window_width as i32 + 1,
+            frame.y - window_height as i32 + 1,
+            has_left || has_top,
+        ),
     ];
 
-    // Find a corner that doesn't overlap with other displays
-    for (x, y) in corners {
-        let overlaps = state.displays.values().any(|other| {
-            if other.id == display_id {
-                return false;
-            }
-            let ox = other.frame.x;
-            let oy = other.frame.y;
-            let ow = other.frame.width as i32;
-            let oh = other.frame.height as i32;
-            x >= ox && x < ox + ow && y >= oy && y < oy + oh
-        });
-        if !overlaps {
+    // Find first safe corner
+    for (x, y, is_unsafe) in corners {
+        if !is_unsafe {
             return (x, y);
         }
     }
 
-    // Fallback (shouldn't normally reach here)
+    // Fallback: use bottom-right (shouldn't normally reach here unless surrounded)
     (
         frame.x + frame.width as i32 - 1,
         frame.y + frame.height as i32 - 1,
@@ -70,18 +175,14 @@ pub fn compute_layout_changes_for_display(
         return vec![];
     };
     let visible_tags = display.visible_tags;
-    let (hide_x, hide_y) = compute_hide_position_for_display(state, display_id);
 
-    let mut moves = Vec::new();
+    // First pass: collect windows that need to be shown or hidden
+    // (window_id, should_show, saved_frame for show, or (width, height) for hide)
+    let mut windows_to_show: Vec<(WindowId, Rect)> = Vec::new();
+    let mut windows_to_hide: Vec<(WindowId, u32, u32)> = Vec::new();
 
-    for window in state.windows.values_mut() {
+    for window in state.windows.values() {
         if window.display_id != display_id {
-            tracing::trace!(
-                "Skipping window {} - display {} != {}",
-                window.id,
-                window.display_id,
-                display_id
-            );
             continue;
         }
 
@@ -101,26 +202,45 @@ pub fn compute_layout_changes_for_display(
         );
 
         if should_be_visible && !is_visible {
-            if let Some(saved) = window.saved_frame.take() {
-                tracing::debug!(
-                    "Showing window {} from ({}, {}) to ({}, {})",
-                    window.id,
-                    window.frame.x,
-                    window.frame.y,
-                    saved.x,
-                    saved.y
-                );
-                moves.push(WindowMove {
-                    window_id: window.id,
-                    pid: window.pid,
-                    old_x: window.frame.x,
-                    old_y: window.frame.y,
-                    new_x: saved.x,
-                    new_y: saved.y,
-                });
-                window.frame = saved;
+            if let Some(saved) = &window.saved_frame {
+                windows_to_show.push((window.id, *saved));
             }
         } else if !should_be_visible && is_visible {
+            windows_to_hide.push((window.id, window.frame.width, window.frame.height));
+        }
+    }
+
+    let mut moves = Vec::new();
+
+    // Process shows
+    for (window_id, saved) in windows_to_show {
+        if let Some(window) = state.windows.get_mut(&window_id) {
+            tracing::debug!(
+                "Showing window {} from ({}, {}) to ({}, {})",
+                window.id,
+                window.frame.x,
+                window.frame.y,
+                saved.x,
+                saved.y
+            );
+            moves.push(WindowMove {
+                window_id: window.id,
+                pid: window.pid,
+                old_x: window.frame.x,
+                old_y: window.frame.y,
+                new_x: saved.x,
+                new_y: saved.y,
+            });
+            window.saved_frame = None;
+            window.frame = saved;
+        }
+    }
+
+    // Process hides (compute hide position per-window)
+    for (window_id, width, height) in windows_to_hide {
+        let (hide_x, hide_y) = compute_hide_position_for_display(state, display_id, width, height);
+
+        if let Some(window) = state.windows.get_mut(&window_id) {
             tracing::debug!(
                 "Hiding window {} from ({}, {}) to ({}, {})",
                 window.id,

--- a/yashiki/src/core/state/rules.rs
+++ b/yashiki/src/core/state/rules.rs
@@ -185,7 +185,12 @@ fn compute_hide_for_window(state: &mut State, window_id: WindowId) -> Option<Win
     }
 
     let visible_tags = state.displays.get(&display_id)?.visible_tags;
-    let (hide_x, hide_y) = super::layout::compute_hide_position_for_display(state, display_id);
+    let (hide_x, hide_y) = super::layout::compute_hide_position_for_display(
+        state,
+        display_id,
+        window_frame.width,
+        window_frame.height,
+    );
 
     let should_be_visible = window_tags.intersects(visible_tags);
 

--- a/yashiki/src/core/state/sync.rs
+++ b/yashiki/src/core/state/sync.rs
@@ -48,7 +48,12 @@ fn detect_rehide_moves(
 
     for window in state.windows.values() {
         if let Some(info) = window_infos.iter().find(|i| i.window_id == window.id) {
-            let (hide_x, hide_y) = compute_hide_position_for_display(state, window.display_id);
+            let (hide_x, hide_y) = compute_hide_position_for_display(
+                state,
+                window.display_id,
+                window.frame.width,
+                window.frame.height,
+            );
             if let Some(mv) = check_window_rehide(
                 window,
                 info.bounds.x as i32,
@@ -264,10 +269,14 @@ pub fn sync_pid<W: WindowSystem>(
             let new_display_id = find_display_for_bounds(state, &info.bounds);
 
             // Compute hide position before mutable borrow
-            let hide_pos = state
-                .windows
-                .get(id)
-                .map(|w| compute_hide_position_for_display(state, w.display_id));
+            let hide_pos = state.windows.get(id).map(|w| {
+                compute_hide_position_for_display(
+                    state,
+                    w.display_id,
+                    w.frame.width,
+                    w.frame.height,
+                )
+            });
 
             if let Some(window) = state.windows.get_mut(id) {
                 let title_changed = window.title != new_title;


### PR DESCRIPTION
macOS window position is the top-left corner, and the window body extends right and down. Previously, hiding windows to non-bottom-right corners caused them to appear on adjacent displays.

This fix passes window dimensions to compute_hide_position_for_display() and offsets the position appropriately:
- bottom-right: no offset (window extends into void)
- bottom-left: x offset by -(width-1)
- top-right: y offset by -(height-1)
- top-left: both offsets

Changes:
- layout.rs: Updated function signature and corner calculations
- sync.rs: Pass window dimensions to hide position calculation
- rules.rs: Pass window dimensions to hide position calculation
- mod.rs: Updated tests with correct expected values
- CLAUDE.md: Added Window Hiding Constraints documentation