### PR TITLE
fix: detect windows from apps running before yashiki started

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,8 @@ macOS tiling window manager written in Rust.
   2. Run `jj status` to confirm current workspace state
 - All file edits must target files under the workspace root path
 - Update only this CLAUDE.md, not the root one
-- **jj write operations (commit, describe, new, etc.) are done by the user, not Claude**
+- **jj write operations (commit, describe, new, etc.) are done by the user, not Claude** (unless explicitly requested)
+  - When user explicitly asks (e.g., "jj describeして", "commitして"), execute the command
   - For PRs: output title and description text, let the user handle jj/git operations
 
 ## Project Structure


### PR DESCRIPTION
Add NSWorkspaceDidActivateApplicationNotification handling to detect when apps that were running before yashiki started open new windows.

Previously, these apps had no AXObserver registered, so their windows would either not be managed or become ghost windows after closing.

The fix adds a two-layer defense:
1. NSWorkspace AppActivated event triggers sync for untracked apps
2. Existing AXObserver ApplicationActivated event serves as fallback

sync_and_process_new_windows handles observer registration internally, avoiding code duplication.