### PR TITLE
fix: ensure rules are applied and retile happens for all window sync paths

### DIFF
--- a/yashiki/src/core/state/display.rs
+++ b/yashiki/src/core/state/display.rs
@@ -20,7 +20,7 @@ pub fn handle_display_change<W: WindowSystem>(state: &mut State, ws: &W) -> Disp
     let added_ids: HashSet<_> = current_ids.difference(&previous_ids).copied().collect();
 
     if removed_ids.is_empty() {
-        let rehide_moves = sync_all(state, ws);
+        let (rehide_moves, new_window_ids) = sync_all(state, ws);
         let mut displays_to_retile: HashSet<DisplayId> = added_ids.iter().copied().collect();
 
         // Restore orphaned windows to their original displays if those displays have returned
@@ -59,6 +59,7 @@ pub fn handle_display_change<W: WindowSystem>(state: &mut State, ws: &W) -> Disp
             displays_to_retile: displays_to_retile.into_iter().collect(),
             added,
             removed: vec![],
+            new_window_ids,
         };
     }
 
@@ -77,6 +78,7 @@ pub fn handle_display_change<W: WindowSystem>(state: &mut State, ws: &W) -> Disp
             displays_to_retile: vec![],
             added: vec![],
             removed: removed_ids,
+            new_window_ids: vec![],
         };
     };
 
@@ -115,7 +117,7 @@ pub fn handle_display_change<W: WindowSystem>(state: &mut State, ws: &W) -> Disp
         state.displays.remove(id);
     }
 
-    let rehide_moves = sync_all(state, ws);
+    let (rehide_moves, new_window_ids) = sync_all(state, ws);
 
     let added: Vec<_> = state
         .displays
@@ -137,6 +139,7 @@ pub fn handle_display_change<W: WindowSystem>(state: &mut State, ws: &W) -> Disp
         displays_to_retile,
         added,
         removed: removed_ids,
+        new_window_ids,
     }
 }
 

--- a/yashiki/src/core/state/mod.rs
+++ b/yashiki/src/core/state/mod.rs
@@ -30,6 +30,7 @@ pub struct DisplayChangeResult {
     pub displays_to_retile: Vec<DisplayId>,
     pub added: Vec<Display>,
     pub removed: Vec<DisplayId>,
+    pub new_window_ids: Vec<WindowId>,
 }
 
 /// Result of focus_output operation
@@ -214,7 +215,7 @@ impl State {
 
     // Sync operations - delegated to state/sync.rs
 
-    pub fn sync_all<W: WindowSystem>(&mut self, ws: &W) -> Vec<WindowMove> {
+    pub fn sync_all<W: WindowSystem>(&mut self, ws: &W) -> (Vec<WindowMove>, Vec<WindowId>) {
         sync_all(self, ws)
     }
 


### PR DESCRIPTION


- Update sync functions to return new_window_ids:
  - sync_all() returns (Vec<WindowMove>, Vec<WindowId>)
  - sync_with_window_infos() returns (Vec<WindowMove>, Vec<WindowId>)
  - DisplayChangeResult includes new_window_ids field

- Add sync_focused_and_process() helper in sync_helper.rs
  - Wraps sync_focused_window_with_hint + process_new_windows
  - Returns SyncResult for caller to check and retile

- Fix AppLaunched/AppActivated handlers to check sync result and retile

- Fix display_source_callback to process new_window_ids from handle_display_change

- Document Window Sync Architecture in CLAUDE.md:
  - Complete flow: sync → apply rules → retile if changed
  - Callers MUST check SyncResult.changed and call do_retile() if true