### PR TITLE
fix: remove ghost windows on app termination

### DIFF
--- a/yashiki/src/app.rs
+++ b/yashiki/src/app.rs
@@ -515,10 +515,9 @@ impl App {
                             }
                         }
 
-                        // Remove windows belonging to this PID from state
-                        // Note: rehide_moves is not needed here as windows are being removed
-                        let (changed, _, _) =
-                            ctx.state.borrow_mut().sync_pid(&ctx.window_system, pid);
+                        // Directly remove windows - no AX API check needed since
+                        // process termination is confirmed by NSWorkspace notification
+                        let changed = ctx.state.borrow_mut().remove_windows_for_pid(pid);
                         if changed {
                             do_retile(
                                 &ctx.state,


### PR DESCRIPTION
When an application terminates, its windows remained as "ghost windows" in state.windows instead of being removed.

Root cause: AppTerminated handler called sync_pid() which checks can_access_ax_windows(pid) before removing windows. For terminated processes, AX API returns errors, causing the check to return false - misinterpreted as "window on different macOS Space" rather than "process terminated."

Solution: Add remove_windows_for_pid() method that directly removes windows without AX API checks, since process termination is already confirmed by NSWorkspace notification.