### PR TITLE
fix: prevent window migration between displays on sleep/wake

### DIFF
--- a/yashiki/src/core/state/sync.rs
+++ b/yashiki/src/core/state/sync.rs
@@ -453,7 +453,6 @@ pub fn sync_pid<W: WindowSystem>(
                 .clone()
                 .unwrap_or_else(|| info.name.clone().unwrap_or_default());
             let new_frame = Rect::from_bounds(&info.bounds);
-            let new_display_id = find_display_for_bounds(state, &info.bounds);
 
             // Compute hide position before mutable borrow
             let hide_pos = state.windows.get(id).map(|w| {
@@ -492,11 +491,11 @@ pub fn sync_pid<W: WindowSystem>(
                             rehide_moves.push(mv);
                         } else if !window.is_hidden() {
                             window.frame = new_frame;
-                            window.display_id = new_display_id;
+                            // Don't update display_id based on position - let orphan handling manage it
                         }
                     } else if !window.is_hidden() {
                         window.frame = new_frame;
-                        window.display_id = new_display_id;
+                        // Don't update display_id based on position - let orphan handling manage it
                     }
                 }
             }
@@ -781,7 +780,6 @@ pub fn sync_with_window_infos<W: WindowSystem>(
 
     // Update existing managed windows
     for info in window_infos {
-        let new_display_id = find_display_for_bounds(state, &info.bounds);
         if let Some(window) = state.windows.get_mut(&info.window_id) {
             let ext = ws.get_extended_attributes(info.window_id, info.pid, info.layer);
             let new_title = ext
@@ -791,7 +789,7 @@ pub fn sync_with_window_infos<W: WindowSystem>(
             window.title = new_title;
             if !window.is_hidden() {
                 window.frame = Rect::from_bounds(&info.bounds);
-                window.display_id = new_display_id;
+                // Don't update display_id based on position - let orphan handling manage it
             }
         }
     }


### PR DESCRIPTION
Problem: When displays reconnect after sleep/wake, macOS may move windows to different positions. yashiki's sync functions were updating display_id based on window position, causing windows to be incorrectly assigned to wrong displays.

Solution:
- Remove position-based display_id updates from sync_pid and sync_with_window_infos
- display_id now only changes via explicit operations:
  1. New window creation (initial assignment)
  2. Orphan processing (display disconnect)
  3. Orphan restoration (display reconnect)
  4. send-to-output command
- Add saved_display_tags to preserve visible_tags across sleep/wake
- Retile all displays on reconnect to handle coordinate shifts

Also:
- Add test for visible_tags restoration
- Document design decisions in CLAUDE.md