### PR TITLE
feat!: output-send keeps focus on source display (River-style)

### DIFF
--- a/yashiki/src/core/state/display.rs
+++ b/yashiki/src/core/state/display.rs
@@ -279,7 +279,7 @@ pub fn send_to_output(state: &mut State, direction: OutputDirection) -> Option<S
     // Compute visibility changes for target display
     let moves = compute_layout_changes_for_display(state, target_display_id);
 
-    state.focused_display = target_display_id;
+    // Note: focused_display is NOT changed (River-style: focus stays on source display)
 
     Some(SendToOutputResult {
         source_display_id,

--- a/yashiki/src/core/state/mod.rs
+++ b/yashiki/src/core/state/mod.rs
@@ -1601,6 +1601,32 @@ mod tests {
     }
 
     #[test]
+    fn test_send_to_output_does_not_change_focused_display() {
+        // send_to_output should NOT change focused_display (River-style)
+        let ws = MockWindowSystem::new()
+            .with_displays(vec![
+                create_test_display(1, 0.0, 0.0, 1920.0, 1080.0),
+                create_test_display(2, 1920.0, 0.0, 1920.0, 1080.0),
+            ])
+            .with_windows(vec![create_test_window(
+                100, 1000, "Safari", 100.0, 100.0, 800.0, 600.0,
+            )])
+            .with_focused(Some(100));
+
+        let mut state = State::new();
+        state.sync_all(&ws);
+        state.focused_display = 1;
+
+        let result = state.send_to_output(OutputDirection::Next);
+        assert!(result.is_some());
+
+        // Window moved to display 2
+        assert_eq!(state.windows.get(&100).unwrap().display_id, 2);
+        // But focused_display should remain on display 1
+        assert_eq!(state.focused_display, 1);
+    }
+
+    #[test]
     fn test_per_display_hide_position_single_display() {
         // Single display should use bottom-right corner
         let ws = MockWindowSystem::new()


### PR DESCRIPTION
BREAKING CHANGE: output-send no longer moves focus to target display.

Previously, output-send would move focused_display to the target display along with the window. Now focus stays on the source display, matching River's behavior. FocusVisibleWindowIfNeeded will focus another visible window on the source display if available.