### PR TITLE
fix: suppress spurious focus changes for multi-window apps

### DIFF
--- a/yashiki/src/app/effects.rs
+++ b/yashiki/src/app/effects.rs
@@ -26,6 +26,9 @@ pub fn execute_effects<M: WindowManipulator>(
                 pid,
                 is_output_change,
             } => {
+                // Set focus intent BEFORE focusing to suppress spurious macOS focus changes
+                state.borrow_mut().set_focus_intent(window_id, pid);
+
                 manipulator.focus_window(window_id, pid);
 
                 // Update state.focused immediately after focusing

--- a/yashiki/src/app/focus.rs
+++ b/yashiki/src/app/focus.rs
@@ -56,6 +56,10 @@ pub fn focus_visible_window_if_needed<M: WindowManipulator>(
 
     if let Some((window_id, pid, (cx, cy))) = window_to_focus {
         tracing::info!("Focusing visible window {} after tag switch", window_id);
+
+        // Set focus intent BEFORE focusing to suppress spurious macOS focus changes
+        state.borrow_mut().set_focus_intent(window_id, pid);
+
         manipulator.focus_window(window_id, pid);
 
         // Update internal state immediately after focusing

--- a/yashiki/src/macos/accessibility.rs
+++ b/yashiki/src/macos/accessibility.rs
@@ -97,6 +97,7 @@ mod attr {
     pub const POSITION: &str = "AXPosition";
     pub const SIZE: &str = "AXSize";
     pub const MINIMIZED: &str = "AXMinimized";
+    pub const MAIN: &str = "AXMain";
     pub const CLOSE_BUTTON: &str = "AXCloseButton";
     pub const SUBROLE: &str = "AXSubrole";
     pub const IDENTIFIER: &str = "AXIdentifier";
@@ -280,6 +281,15 @@ impl AXUIElement {
             CFBoolean::false_value()
         };
         self.set_attribute(attr::MINIMIZED, value.as_CFTypeRef())
+    }
+
+    pub fn set_main(&self, value: bool) -> Result<(), AXError> {
+        let cf_value = if value {
+            CFBoolean::true_value()
+        } else {
+            CFBoolean::false_value()
+        };
+        self.set_attribute(attr::MAIN, cf_value.as_CFTypeRef())
     }
 
     pub fn windows(&self) -> Result<Vec<AXUIElement>, AXError> {


### PR DESCRIPTION
When yashiki focuses a window, macOS may redirect focus to a different window of the same app (e.g., Firefox with windows on multiple displays). This caused unexpected focus jumping between displays during tag switches.

Changes:
- Improve check_spurious_focus_change() to suppress any focus change to a different window of the same app within the 200ms suppression window (previously only suppressed focus to hidden windows)
- Document FocusIntent mechanism in CLAUDE.md Design Decisions section

The FocusIntent mechanism now:
1. Records intended focus target with set_focus_intent()
2. Suppresses focus changes to ANY different window of same PID
3. Refocuses to intended window when spurious change detected