### PR TITLE
feat: add auto-raise (focus follows mouse) feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ macOS tiling window manager written in Rust.
 - **Multi-monitor support** - Each display has independent tags
 - **Window rules** - Automatically configure windows by app name, bundle identifier, or title
 - **Cursor warp** - Mouse follows focus (configurable: disabled, on-output-change, on-focus-change)
+- **Auto-raise** - Focus follows mouse with optional delay (focus window when cursor enters)
 - **State streaming** - Real-time events for status bars and external tools
 - **No SIP disable required** - Uses only public Accessibility API
 - **Shell script configuration** - Config is just a shell script (`~/.config/yashiki/init`)
@@ -238,6 +239,17 @@ yashiki set-cursor-warp disabled          # Don't move cursor (default)
 yashiki set-cursor-warp on-output-change  # Move cursor when switching displays
 yashiki set-cursor-warp on-focus-change   # Always move cursor to focused window
 yashiki get-cursor-warp                   # Get current mode
+```
+
+### Auto-Raise
+
+Focus follows mouse - automatically focus windows when the cursor enters them.
+
+```sh
+yashiki set-auto-raise disabled           # Don't auto-focus (default)
+yashiki set-auto-raise enabled            # Focus window immediately when cursor enters
+yashiki set-auto-raise enabled --delay 100  # Wait 100ms before focusing (useful when moving across windows)
+yashiki get-auto-raise                    # Get current mode and delay
 ```
 
 ### Outer Gap

--- a/completions/zsh/_yashiki
+++ b/completions/zsh/_yashiki
@@ -32,6 +32,14 @@ _yashiki_cursor_warp_modes() {
     _describe -t modes 'mode' modes
 }
 
+_yashiki_auto_raise_modes() {
+    local modes=(
+        'disabled:Do not auto-focus windows on hover'
+        'enabled:Focus window when cursor enters'
+    )
+    _describe -t modes 'mode' modes
+}
+
 _yashiki_layouts() {
     local layouts=(
         'tatami:Master-stack layout'
@@ -124,6 +132,8 @@ _yashiki_subcommands() {
         'list-rules:List all window rules'
         'set-cursor-warp:Set cursor warp mode'
         'get-cursor-warp:Get current cursor warp mode'
+        'set-auto-raise:Set auto-raise mode (focus follows mouse)'
+        'get-auto-raise:Get current auto-raise mode'
         'set-outer-gap:Set outer gap'
         'get-outer-gap:Get current outer gap'
         'subscribe:Subscribe to state change events'
@@ -183,7 +193,7 @@ _yashiki() {
     case $state in
         args)
             case $line[1] in
-                start|version|list-bindings|tag-view-last|window-toggle-fullscreen|window-toggle-float|window-close|list-outputs|get-state|focused-window|exec-path|list-rules|get-cursor-warp|get-outer-gap|quit)
+                start|version|list-bindings|tag-view-last|window-toggle-fullscreen|window-toggle-float|window-close|list-outputs|get-state|focused-window|exec-path|list-rules|get-cursor-warp|get-auto-raise|get-outer-gap|quit)
                     # No arguments
                     ;;
                 bind)
@@ -260,6 +270,11 @@ _yashiki() {
                     ;;
                 set-cursor-warp)
                     _arguments '1:mode:_yashiki_cursor_warp_modes'
+                    ;;
+                set-auto-raise)
+                    _arguments \
+                        '--delay=[Delay in milliseconds before raising]:delay (ms):' \
+                        '1:mode:_yashiki_auto_raise_modes'
                     ;;
                 set-outer-gap)
                     _arguments '*:gap value:'

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -356,6 +356,9 @@ yashiki layout-cmd --layout tatami set-inner-gap 10
 # Cursor warp (mouse follows focus)
 yashiki set-cursor-warp on-focus-change
 
+# Auto-raise (focus follows mouse) - with 100ms delay to avoid accidental focus changes
+yashiki set-auto-raise enabled --delay 100
+
 # Tags
 for i in 1 2 3 4 5 6 7 8 9; do
   yashiki bind "alt-$i" tag-view "$((1<<(i-1)))"
@@ -406,6 +409,9 @@ yashiki layout-cmd --layout byobu set-padding 40
 
 # Cursor warp
 yashiki set-cursor-warp on-focus-change
+
+# Auto-raise (focus follows mouse)
+yashiki set-auto-raise enabled --delay 100
 
 # Tags (all 9 tags)
 for i in 1 2 3 4 5 6 7 8 9; do

--- a/yashiki-ipc/src/command.rs
+++ b/yashiki-ipc/src/command.rs
@@ -12,6 +12,15 @@ pub enum CursorWarpMode {
     OnFocusChange,
 }
 
+/// Auto-raise mode - controls focus follows mouse behavior
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum AutoRaiseMode {
+    #[default]
+    Disabled,
+    Enabled,
+}
+
 /// Window status - indicates whether a window is managed or ignored
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -694,6 +703,13 @@ pub enum Command {
     },
     GetCursorWarp,
 
+    // Auto-raise (focus follows mouse)
+    SetAutoRaise {
+        mode: AutoRaiseMode,
+        delay_ms: u64,
+    },
+    GetAutoRaise,
+
     // Outer gap
     SetOuterGap {
         values: Vec<String>,
@@ -743,6 +759,7 @@ pub enum Response {
     Layout { layout: String },
     ExecPath { path: String },
     CursorWarp { mode: CursorWarpMode },
+    AutoRaise { mode: AutoRaiseMode, delay_ms: u64 },
     OuterGap { outer_gap: OuterGap },
 }
 

--- a/yashiki-ipc/src/lib.rs
+++ b/yashiki-ipc/src/lib.rs
@@ -4,7 +4,7 @@ pub mod layout;
 pub mod outer_gap;
 
 pub use command::{
-    BindingInfo, ButtonInfo, ButtonState, Command, CursorWarpMode, Direction,
+    AutoRaiseMode, BindingInfo, ButtonInfo, ButtonState, Command, CursorWarpMode, Direction,
     ExtendedWindowAttributes, GlobPattern, OutputDirection, OutputInfo, OutputSpecifier, Response,
     RuleAction, RuleInfo, RuleMatcher, StateInfo, WindowInfo, WindowLevel, WindowLevelName,
     WindowLevelOther, WindowRule, WindowStatus,

--- a/yashiki/src/app/command.rs
+++ b/yashiki/src/app/command.rs
@@ -549,6 +549,24 @@ pub fn process_command(
             mode: state.config.cursor_warp,
         }),
 
+        // Auto-raise
+        Command::SetAutoRaise { mode, delay_ms } => {
+            use yashiki_ipc::AutoRaiseMode;
+            tracing::info!("Set auto-raise mode: {:?}, delay: {}ms", mode, delay_ms);
+            state.config.auto_raise_mode = *mode;
+            state.config.auto_raise_delay_ms = *delay_ms;
+            // Clear auto-raise state when disabled
+            if *mode == AutoRaiseMode::Disabled {
+                state.auto_raise_state = Default::default();
+            }
+            // MouseTracker start/stop is handled in ipc_source_callback after command processing
+            CommandResult::ok()
+        }
+        Command::GetAutoRaise => CommandResult::with_response(Response::AutoRaise {
+            mode: state.config.auto_raise_mode,
+            delay_ms: state.config.auto_raise_delay_ms,
+        }),
+
         // Outer gap
         Command::SetOuterGap { values } => match OuterGap::from_args(values) {
             Some(gap) => {

--- a/yashiki/src/core/config.rs
+++ b/yashiki/src/core/config.rs
@@ -1,4 +1,4 @@
-use yashiki_ipc::{CursorWarpMode, OuterGap};
+use yashiki_ipc::{AutoRaiseMode, CursorWarpMode, OuterGap};
 
 /// Application configuration settings.
 /// Grouped separately from window/display state for clarity.
@@ -6,6 +6,8 @@ use yashiki_ipc::{CursorWarpMode, OuterGap};
 pub struct Config {
     pub exec_path: String,
     pub cursor_warp: CursorWarpMode,
+    pub auto_raise_mode: AutoRaiseMode,
+    pub auto_raise_delay_ms: u64,
     pub outer_gap: OuterGap,
     pub init_completed: bool,
 }

--- a/yashiki/src/macos/mod.rs
+++ b/yashiki/src/macos/mod.rs
@@ -1,11 +1,13 @@
 mod accessibility;
 mod display;
 mod hotkey;
+mod mouse_tracker;
 mod observer;
 mod workspace;
 
 pub use accessibility::*;
 pub use display::*;
 pub use hotkey::*;
+pub use mouse_tracker::*;
 pub use observer::*;
 pub use workspace::*;

--- a/yashiki/src/macos/mouse_tracker.rs
+++ b/yashiki/src/macos/mouse_tracker.rs
@@ -1,0 +1,169 @@
+use std::ffi::c_void;
+use std::ptr;
+use std::sync::atomic::{AtomicPtr, Ordering};
+use std::sync::mpsc;
+use std::sync::Arc;
+
+use core_foundation::base::TCFType;
+use core_foundation::runloop::{kCFRunLoopCommonModes, CFRunLoop, CFRunLoopSource};
+use core_foundation_sys::mach_port::CFMachPortRef;
+use core_foundation_sys::runloop::{CFRunLoopSourceRef, CFRunLoopSourceSignal};
+use core_graphics::event::{
+    CGEventTap, CGEventTapLocation, CGEventTapOptions, CGEventTapPlacement, CGEventType,
+    CallbackResult,
+};
+
+extern "C" {
+    fn CGEventTapEnable(tap: CFMachPortRef, enable: bool);
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct MousePosition {
+    pub x: i32,
+    pub y: i32,
+}
+
+pub struct MouseTracker {
+    event_tx: mpsc::Sender<MousePosition>,
+    tap: Option<MouseTap>,
+    runloop_source: Arc<AtomicPtr<c_void>>,
+    last_position: Arc<std::sync::Mutex<Option<MousePosition>>>,
+}
+
+impl MouseTracker {
+    pub fn new(
+        event_tx: mpsc::Sender<MousePosition>,
+        runloop_source: Arc<AtomicPtr<c_void>>,
+    ) -> Self {
+        Self {
+            event_tx,
+            tap: None,
+            runloop_source,
+            last_position: Arc::new(std::sync::Mutex::new(None)),
+        }
+    }
+
+    pub fn start(&mut self) -> Result<(), String> {
+        if self.tap.is_some() {
+            return Ok(());
+        }
+        self.tap = Some(self.create_tap()?);
+        tracing::info!("Mouse tracker started");
+        Ok(())
+    }
+
+    pub fn stop(&mut self) {
+        if self.tap.take().is_some() {
+            tracing::info!("Mouse tracker stopped");
+        }
+    }
+
+    pub fn is_running(&self) -> bool {
+        self.tap.is_some()
+    }
+
+    fn create_tap(&self) -> Result<MouseTap, String> {
+        let tx = self.event_tx.clone();
+        let source = Arc::clone(&self.runloop_source);
+        let last_pos = Arc::clone(&self.last_position);
+
+        let mach_port_ptr: Arc<AtomicPtr<c_void>> = Arc::new(AtomicPtr::new(ptr::null_mut()));
+        let mach_port_for_callback = Arc::clone(&mach_port_ptr);
+
+        // Throttle threshold: only send if position changed by at least 5px
+        const THROTTLE_THRESHOLD: i32 = 5;
+
+        let tap = CGEventTap::new(
+            CGEventTapLocation::Session,
+            CGEventTapPlacement::HeadInsertEventTap,
+            CGEventTapOptions::ListenOnly,
+            vec![CGEventType::MouseMoved],
+            move |_proxy, event_type, event| {
+                match event_type {
+                    CGEventType::TapDisabledByTimeout | CGEventType::TapDisabledByUserInput => {
+                        let reason = if matches!(event_type, CGEventType::TapDisabledByTimeout) {
+                            "timeout"
+                        } else {
+                            "user input"
+                        };
+                        tracing::warn!("Mouse event tap disabled by {}, re-enabling...", reason);
+                        let ptr = mach_port_for_callback.load(Ordering::Acquire);
+                        if !ptr.is_null() {
+                            unsafe {
+                                CGEventTapEnable(ptr as CFMachPortRef, true);
+                            }
+                        }
+                        return CallbackResult::Keep;
+                    }
+                    _ => {}
+                }
+
+                let location = event.location();
+                let new_pos = MousePosition {
+                    x: location.x as i32,
+                    y: location.y as i32,
+                };
+
+                // Throttle: only send if position changed significantly
+                let should_send = {
+                    let mut last = last_pos.lock().unwrap();
+                    match *last {
+                        Some(prev) => {
+                            let dx = (new_pos.x - prev.x).abs();
+                            let dy = (new_pos.y - prev.y).abs();
+                            if dx >= THROTTLE_THRESHOLD || dy >= THROTTLE_THRESHOLD {
+                                *last = Some(new_pos);
+                                true
+                            } else {
+                                false
+                            }
+                        }
+                        None => {
+                            *last = Some(new_pos);
+                            true
+                        }
+                    }
+                };
+
+                if should_send && tx.send(new_pos).is_ok() {
+                    // Signal CFRunLoopSource for immediate processing
+                    let source_ptr = source.load(Ordering::Acquire);
+                    if !source_ptr.is_null() {
+                        unsafe {
+                            CFRunLoopSourceSignal(source_ptr as CFRunLoopSourceRef);
+                        }
+                    }
+                }
+
+                CallbackResult::Keep
+            },
+        )
+        .map_err(|_| {
+            "Failed to create mouse event tap. Make sure Accessibility permission is granted."
+        })?;
+
+        mach_port_ptr.store(
+            tap.mach_port().as_concrete_TypeRef() as *mut c_void,
+            Ordering::Release,
+        );
+
+        tap.enable();
+
+        let source = tap
+            .mach_port()
+            .create_runloop_source(0)
+            .map_err(|_| "Failed to create run loop source for mouse tracker")?;
+
+        CFRunLoop::get_current().add_source(&source, unsafe { kCFRunLoopCommonModes });
+
+        Ok(MouseTap {
+            _tap: tap,
+            _source: source,
+        })
+    }
+}
+
+struct MouseTap {
+    _tap: CGEventTap<'static>,
+    _source: CFRunLoopSource,
+}


### PR DESCRIPTION
Implement built-in auto-raise functionality to replace external AutoRaise tools. When enabled, windows automatically receive focus when the cursor enters them.

Features:
- Two modes: disabled (default), enabled
- Optional delay (in ms) before raising - useful when moving cursor across windows
- Integrates with FocusIntent mechanism to suppress spurious macOS focus changes
- CGEventTap only runs when enabled (no overhead when disabled)
- Throttled to 5px movement threshold to reduce CPU usage

CLI:
- yashiki set-auto-raise disabled|enabled [--delay ms]
- yashiki get-auto-raise

Implementation:
- New MouseTracker module using CGEventTap for MouseMoved events
- AutoRaiseState in State for tracking hover state
- find_window_at_point() helper for hit testing

Known limitation:
- Overlapping floating windows don't consider z-order (to be addressed with "floating windows always on top" feature)