### PR TITLE
refactor: integrate tag-view sync with sync_helper pattern

### DIFF
--- a/yashiki/src/app.rs
+++ b/yashiki/src/app.rs
@@ -230,6 +230,7 @@ impl App {
                     &ctx.window_system,
                     &ctx.window_manipulator,
                     &ctx.event_emitter,
+                    &ctx.observer_manager,
                 );
                 let _ = resp_tx.blocking_send(response);
 
@@ -332,6 +333,7 @@ impl App {
                     &ctx.window_system,
                     &ctx.window_manipulator,
                     &ctx.event_emitter,
+                    &ctx.observer_manager,
                 );
             }
         }

--- a/yashiki/src/core/state/mod.rs
+++ b/yashiki/src/core/state/mod.rs
@@ -411,6 +411,14 @@ impl State {
         sync_pid(self, ws, pid)
     }
 
+    pub fn sync_windows_for_display<W: WindowSystem>(
+        &mut self,
+        ws: &W,
+        display_id: DisplayId,
+    ) -> (bool, Vec<WindowId>, Vec<WindowMove>) {
+        sync_windows_for_display(self, ws, display_id)
+    }
+
     pub fn handle_event<W: WindowSystem>(
         &mut self,
         ws: &W,


### PR DESCRIPTION
- Update sync_windows_for_display to return new_window_ids
- Add sync_display_and_process_new_windows helper to sync_helper.rs
- Add observer_manager parameter to dispatch_command
- Ensures rule application and WindowCreated events for windows discovered during tag-view commands
- Follows documented Window Sync Architecture principles