### PR TITLE
Refactor attribute handling to centralize CFString runtime checks in …

### DIFF
--- a/yashiki/src/macos/accessibility.rs
+++ b/yashiki/src/macos/accessibility.rs
@@ -203,6 +203,7 @@ impl AXUIElement {
                 ty,
                 str_ty
             );
+            unsafe { core_foundation::base::CFRelease(value as *const _) };
             return Err(AX_ERROR_FAILURE);
         }
 


### PR DESCRIPTION
## Summary

This PR fixes a crash that caused `yashiki start` to fail on macOS during startup.\
The root cause was an **Objective-C exception crossing the Rust FFI boundary**, triggered by assuming that certain macOS Accessibility attributes were always returned as `CFString`.

The fix adds **runtime CFType checks** and safely handles non-string values, preventing foreign exceptions from aborting the process.

---

## Background / Problem

After upgrading to v0.10.1 and adding several configuration options, `yashiki start` suddenly began failing with the following error:

```text
yashiki start
fatal runtime error: Rust cannot catch foreign exceptions, aborting
```

To investigate, I opened the source in RustRover and debugged the startup sequence using LLDB, setting breakpoints on Objective-C exceptions.

---

## Root Cause

The LLDB backtrace clearly indicated that the crash was caused by an Objective-C exception:

```
-[NSObject doesNotRecognizeSelector:]
core_foundation::string::From<&CFString> for Cow<str>::from
AXUIElement::identifier (accessibility.rs:357)
```

### Explanation

- `AXUIElementCopyAttributeValue` does **not guarantee** that returned values are always `CFString`
- Depending on the application or window, the value may be:
  - `kCFNull`
  - another CF / Objective-C object
  - missing entirely
- The current implementation unconditionally treated these values as `CFString` and called `to_string()`
- When the value was not actually a string, Objective-C raised `doesNotRecognizeSelector:`
- Since this exception crossed the Rust FFI boundary, the process aborted

---

## Fix / Approach

This PR introduces **runtime CFType validation** on the Rust side and only converts values that are actually `CFString`.

### Strategy

1. Retrieve the runtime type using `CFGetTypeID(value)`
2. Compare it with `CFStringGetTypeID()`
3. Convert to `CFString` **only if the types match**
4. Otherwise, return `Err(...)`
5. Callers use `.ok()` to safely drop invalid values

This prevents Objective-C exceptions from escaping into Rust and allows the daemon to start safely.

---

## Code Changes

### Added

- FFI bindings for CFType runtime checks
- A shared helper method `get_attribute_string()`

```rust
fn CFGetTypeID(cf: *const c_void) -> CFTypeID;
fn CFStringGetTypeID() -> CFTypeID;
```

```rust
fn get_attribute_string(&self, name: &str) -> Result<String, AXError> {
    let value = self.get_attribute(name)?;

    let ty = unsafe { CFGetTypeID(value as *const c_void) };
    let str_ty = unsafe { CFStringGetTypeID() };
    if ty != str_ty {
        tracing::debug!(
            "AX attribute '{}' is not a CFString (type_id={} expected={})",
            name,
            ty,
            str_ty
        );
        return Err(AX_ERROR_FAILURE);
    }

    let cf = unsafe { CFString::wrap_under_create_rule(value as *const _) };
    Ok(cf.to_string())
}
```

### Updated Call Sites

The following methods now use `get_attribute_string()`:

- `title`
- `subrole`
- `identifier`

---

## Result

- `yashiki start` no longer crashes at startup
- The macOS Accessibility integration is now robust against attribute type inconsistencies
- Unexpected AX attribute values are handled safely and logged for debugging

---

## Notes

- This change is intentionally conservative and does not affect valid string cases
- Debug logging makes future investigations easier if similar issues arise
