### PR TITLE
fix: skip AX check for non-normal layer windows in removal logic

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -373,6 +373,9 @@ The `should_remove_window` helper in `core/state/sync.rs` encapsulates both chec
 - Process-level: Handles apps on different macOS Spaces (entire process inaccessible)
 - Window-level: Handles transitioning windows (process accessible, specific window temporarily invisible to CGWindowList but still in AX)
 
+**Non-normal layer windows (`level != 0`):**
+System dialogs (File Picker, etc.) are not included in `AXWindows` attribute, so `window_exists_in_ax` check is skipped for these windows. They are removed only when they disappear from CGWindowList.
+
 **Related code:**
 - `platform.rs`: `WindowSystem::window_exists_in_ax()` trait method
 - `core/state/sync.rs`: `should_remove_window()`, `sync_pid()`, `sync_with_window_infos()`

--- a/yashiki/src/app.rs
+++ b/yashiki/src/app.rs
@@ -377,6 +377,8 @@ impl App {
             use std::time::Instant;
             use yashiki_ipc::AutoRaiseMode;
 
+            use crate::core::WindowAtPoint;
+
             // Process all pending mouse events
             while let Ok(pos) = ctx.mouse_event_rx.try_recv() {
                 // Check if auto-raise is enabled
@@ -387,8 +389,14 @@ impl App {
 
                 let delay_ms = ctx.state.borrow().config.auto_raise_delay_ms;
 
-                // Find window at cursor position
-                let window_info = ctx.state.borrow().find_window_at_point(pos.x, pos.y);
+                // Find topmost window at cursor position (managed or ignored)
+                let window_at_point = ctx.state.borrow().find_window_at_point(pos.x, pos.y);
+
+                // Extract window_id and pid from WindowAtPoint (both variants handled the same)
+                let window_info = window_at_point.map(|w| match w {
+                    WindowAtPoint::Managed { window_id, pid } => (window_id, pid),
+                    WindowAtPoint::Ignored { window_id, pid } => (window_id, pid),
+                });
 
                 match window_info {
                     Some((window_id, pid)) => {

--- a/yashiki/src/app/effects.rs
+++ b/yashiki/src/app/effects.rs
@@ -33,8 +33,13 @@ pub fn execute_effects<M: WindowManipulator>(
 
                 // Update state.focused immediately after focusing
                 // This ensures consecutive focus commands work correctly
-                // even if accessibility events are delayed or missing
-                state.borrow_mut().set_focused(Some(window_id));
+                // even if accessibility events are delayed or missing.
+                // Also update z-order cache to reflect the new front window.
+                {
+                    let mut s = state.borrow_mut();
+                    s.set_focused(Some(window_id));
+                    s.move_to_front_in_z_order(window_id);
+                }
 
                 // Warp cursor based on cursor_warp mode
                 let cursor_warp_mode = state.borrow().config.cursor_warp;

--- a/yashiki/src/app/focus.rs
+++ b/yashiki/src/app/focus.rs
@@ -41,11 +41,11 @@ pub fn focus_visible_window_if_needed<M: WindowManipulator>(
             return;
         }
 
-        // Focus the first visible window (prefer tiled, then fullscreen, then floating)
+        // Focus the first visible window (prefer fullscreen, then tiled, then floating)
         let window = all_visible
             .iter()
-            .find(|w| w.is_tiled())
-            .or_else(|| all_visible.iter().find(|w| w.is_fullscreen))
+            .find(|w| w.is_fullscreen)
+            .or_else(|| all_visible.iter().find(|w| w.is_tiled()))
             .or_else(|| all_visible.first());
 
         match window {


### PR DESCRIPTION
System dialogs (File Picker, etc.) are reported under the parent app's PID in CGWindowList but are not included in the AXWindows attribute. The existing window_exists_in_ax check would incorrectly determine these windows as "not in AX" and remove them prematurely.

Changes:
- Add window_level field to IgnoredWindowInfo to track layer level
- Modify should_remove_window to skip AX check for level != 0 windows
- Update all call sites in sync_pid and sync_with_window_infos
- Update IgnoredWindowInfo on re-evaluation to keep window_level in sync

This fixes auto-raise not working correctly for Firefox File Dialog, which was being removed immediately after detection because it wasn't found in AXWindows.