### PR TITLE
feat: add cross-display focus redirect suppression

### DIFF
--- a/yashiki/src/app.rs
+++ b/yashiki/src/app.rs
@@ -409,8 +409,20 @@ impl App {
                                 if start.elapsed().as_millis() >= delay_ms as u128 {
                                     // Delay elapsed - check if already focused
                                     if state.focused != Some(window_id) {
+                                        // Get display_id for focus intent
+                                        let display_id = state
+                                            .windows
+                                            .get(&window_id)
+                                            .map(|w| w.display_id)
+                                            .or_else(|| {
+                                                state
+                                                    .ignored_windows
+                                                    .get(&window_id)
+                                                    .map(|w| w.display_id)
+                                            })
+                                            .unwrap_or(0);
                                         // Set focus intent before focusing
-                                        state.set_focus_intent(window_id, pid);
+                                        state.set_focus_intent(window_id, pid, display_id);
                                         drop(state); // Release borrow before manipulator call
                                         tracing::debug!(
                                             "Auto-raise: focusing window {} at ({}, {})",

--- a/yashiki/src/app/effects.rs
+++ b/yashiki/src/app/effects.rs
@@ -27,7 +27,12 @@ pub fn execute_effects<M: WindowManipulator>(
                 is_output_change,
             } => {
                 // Set focus intent BEFORE focusing to suppress spurious macOS focus changes
-                state.borrow_mut().set_focus_intent(window_id, pid);
+                let display_id = state.borrow().windows.get(&window_id).map(|w| w.display_id);
+                if let Some(display_id) = display_id {
+                    state
+                        .borrow_mut()
+                        .set_focus_intent(window_id, pid, display_id);
+                }
 
                 manipulator.focus_window(window_id, pid);
 
@@ -154,4 +159,45 @@ pub fn execute_effects<M: WindowManipulator>(
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::platform::mock::{
+        create_test_display, create_test_window, MockWindowManipulator, MockWindowSystem,
+    };
+
+    #[test]
+    fn test_focus_window_effect_sets_focus_intent() {
+        let ws = MockWindowSystem::new()
+            .with_displays(vec![create_test_display(1, 0.0, 0.0, 1920.0, 1080.0)])
+            .with_windows(vec![create_test_window(
+                100, 1000, "Firefox", 100.0, 100.0, 800.0, 600.0,
+            )])
+            .with_focused(Some(100));
+
+        let mut state = State::new();
+        state.sync_all(&ws);
+
+        let state = RefCell::new(state);
+        let layout_engine_manager = RefCell::new(LayoutEngineManager::new());
+        let manipulator = MockWindowManipulator::new();
+
+        let effects = vec![Effect::FocusWindow {
+            window_id: 100,
+            pid: 1000,
+            is_output_change: false,
+        }];
+
+        // This should not panic due to RefCell borrow conflict
+        execute_effects(effects, &state, &layout_engine_manager, &manipulator).unwrap();
+
+        // Verify focus_intent was set
+        assert!(state.borrow().focus_intent.is_some());
+        let intent = state.borrow().focus_intent.clone().unwrap();
+        assert_eq!(intent.window_id, 100);
+        assert_eq!(intent.pid, 1000);
+        assert_eq!(intent.display_id, 1);
+    }
 }

--- a/yashiki/src/app/focus.rs
+++ b/yashiki/src/app/focus.rs
@@ -49,16 +49,21 @@ pub fn focus_visible_window_if_needed<M: WindowManipulator>(
             .or_else(|| all_visible.first());
 
         match window {
-            Some(w) => (Some((w.id, w.pid, w.center())), state.config.cursor_warp),
+            Some(w) => (
+                Some((w.id, w.pid, w.display_id, w.center())),
+                state.config.cursor_warp,
+            ),
             None => return,
         }
     };
 
-    if let Some((window_id, pid, (cx, cy))) = window_to_focus {
+    if let Some((window_id, pid, display_id, (cx, cy))) = window_to_focus {
         tracing::info!("Focusing visible window {} after tag switch", window_id);
 
         // Set focus intent BEFORE focusing to suppress spurious macOS focus changes
-        state.borrow_mut().set_focus_intent(window_id, pid);
+        state
+            .borrow_mut()
+            .set_focus_intent(window_id, pid, display_id);
 
         manipulator.focus_window(window_id, pid);
 
@@ -85,6 +90,20 @@ pub fn switch_tag_for_focused_window(state: &RefCell<State>) -> Option<Vec<Windo
             window.is_hidden(),
         )
     };
+
+    // Check for cross-display spurious focus redirect
+    // This happens when yashiki focuses a window on one display and macOS redirects
+    // focus to a different window of the same app on another display
+    if state
+        .borrow()
+        .should_suppress_cross_display_tag_switch(focused_id)
+    {
+        tracing::info!(
+            "Skipping tag switch for window {} - detected cross-display focus redirect",
+            focused_id
+        );
+        return None;
+    }
 
     // Check if window is visible on its display's current visible tags
     let is_visible = {

--- a/yashiki/src/core/state/mod.rs
+++ b/yashiki/src/core/state/mod.rs
@@ -95,17 +95,22 @@ pub struct TrackedProcess {
 pub struct FocusIntent {
     pub window_id: WindowId,
     pub pid: i32,
+    pub display_id: DisplayId,
     pub timestamp: Instant,
 }
 
 impl FocusIntent {
     /// Duration to suppress re-hide and external focus changes for the same app
     pub const SUPPRESSION_DURATION_MS: u128 = 200;
+    /// Duration to suppress cross-display tag switches (longer, since cross-display
+    /// focus redirect within this window is almost certainly spurious macOS behavior)
+    pub const CROSS_DISPLAY_SUPPRESSION_DURATION_MS: u128 = 500;
 
-    pub fn new(window_id: WindowId, pid: i32) -> Self {
+    pub fn new(window_id: WindowId, pid: i32, display_id: DisplayId) -> Self {
         Self {
             window_id,
             pid,
+            display_id,
             timestamp: Instant::now(),
         }
     }
@@ -113,6 +118,11 @@ impl FocusIntent {
     /// Check if this intent is still active (within suppression window)
     pub fn is_active(&self) -> bool {
         self.timestamp.elapsed().as_millis() < Self::SUPPRESSION_DURATION_MS
+    }
+
+    /// Check if this intent is still active for cross-display suppression (longer window)
+    pub fn is_active_for_cross_display(&self) -> bool {
+        self.timestamp.elapsed().as_millis() < Self::CROSS_DISPLAY_SUPPRESSION_DURATION_MS
     }
 
     /// Check if a given pid matches this intent and is still active
@@ -307,8 +317,8 @@ impl State {
 
     /// Set the focus intent when intentionally focusing a window.
     /// This helps suppress spurious macOS focus changes to other windows of the same app.
-    pub fn set_focus_intent(&mut self, window_id: WindowId, pid: i32) {
-        self.focus_intent = Some(FocusIntent::new(window_id, pid));
+    pub fn set_focus_intent(&mut self, window_id: WindowId, pid: i32, display_id: DisplayId) {
+        self.focus_intent = Some(FocusIntent::new(window_id, pid, display_id));
     }
 
     /// Move a window to the front of the z-order cache.
@@ -359,6 +369,45 @@ impl State {
         }
 
         None
+    }
+
+    /// Check if automatic tag switching should be suppressed for cross-display focus redirect.
+    /// Returns true if:
+    /// - FocusIntent is active (within 500ms for cross-display)
+    /// - New focused window has same PID as intended
+    /// - New focused window is on a DIFFERENT display than intended
+    ///
+    /// This handles cases where macOS redirects focus to a different window of the same app
+    /// on a different display, which would otherwise trigger unwanted tag switching.
+    pub fn should_suppress_cross_display_tag_switch(&self, new_focused_id: WindowId) -> bool {
+        let Some(intent) = self.focus_intent.as_ref() else {
+            return false;
+        };
+        if !intent.is_active_for_cross_display() {
+            return false;
+        }
+
+        let Some(new_window) = self.windows.get(&new_focused_id) else {
+            return false;
+        };
+
+        // Different app - not spurious
+        if new_window.pid != intent.pid {
+            return false;
+        }
+
+        // Same app but different display - suppress tag switch
+        if new_window.display_id != intent.display_id {
+            tracing::debug!(
+                "Suppressing cross-display tag switch: window {} on display {} (intended: display {})",
+                new_focused_id,
+                new_window.display_id,
+                intent.display_id
+            );
+            return true;
+        }
+
+        false
     }
 
     /// Remove all windows belonging to a terminated process.
@@ -2972,5 +3021,304 @@ mod tests {
         assert_eq!(state.windows.len(), 1);
         assert!(state.windows.contains_key(&100));
         assert!(!state.windows.contains_key(&101));
+    }
+
+    // FocusIntent tests
+
+    impl FocusIntent {
+        /// Create FocusIntent with a specified elapsed time (for testing)
+        fn with_elapsed_ms(
+            window_id: WindowId,
+            pid: i32,
+            display_id: DisplayId,
+            elapsed_ms: u64,
+        ) -> Self {
+            Self {
+                window_id,
+                pid,
+                display_id,
+                timestamp: Instant::now() - Duration::from_millis(elapsed_ms),
+            }
+        }
+    }
+
+    #[test]
+    fn test_check_spurious_focus_change_no_intent() {
+        let ws = MockWindowSystem::new()
+            .with_displays(vec![create_test_display(1, 0.0, 0.0, 1920.0, 1080.0)])
+            .with_windows(vec![create_test_window(
+                100, 1000, "Firefox", 100.0, 100.0, 800.0, 600.0,
+            )])
+            .with_focused(Some(100));
+
+        let mut state = State::new();
+        state.sync_all(&ws);
+
+        // No focus intent set
+        assert!(state.focus_intent.is_none());
+
+        // Should return None when no intent
+        assert!(state.check_spurious_focus_change(100).is_none());
+    }
+
+    #[test]
+    fn test_check_spurious_focus_change_expired() {
+        let ws = MockWindowSystem::new()
+            .with_displays(vec![create_test_display(1, 0.0, 0.0, 1920.0, 1080.0)])
+            .with_windows(vec![
+                create_test_window(100, 1000, "Firefox", 100.0, 100.0, 800.0, 600.0),
+                create_test_window(101, 1000, "Firefox", 200.0, 200.0, 800.0, 600.0),
+            ])
+            .with_focused(Some(100));
+
+        let mut state = State::new();
+        state.sync_all(&ws);
+
+        // Set expired focus intent (>200ms)
+        state.focus_intent = Some(FocusIntent::with_elapsed_ms(100, 1000, 1, 250));
+
+        // Should return None when expired
+        assert!(state.check_spurious_focus_change(101).is_none());
+    }
+
+    #[test]
+    fn test_check_spurious_focus_change_different_pid() {
+        let ws = MockWindowSystem::new()
+            .with_displays(vec![create_test_display(1, 0.0, 0.0, 1920.0, 1080.0)])
+            .with_windows(vec![
+                create_test_window(100, 1000, "Firefox", 100.0, 100.0, 800.0, 600.0),
+                create_test_window(101, 1001, "Safari", 200.0, 200.0, 800.0, 600.0),
+            ])
+            .with_focused(Some(100));
+
+        let mut state = State::new();
+        state.sync_all(&ws);
+
+        // Set focus intent for Firefox (pid 1000)
+        state.focus_intent = Some(FocusIntent::with_elapsed_ms(100, 1000, 1, 0));
+
+        // Focus change to Safari (pid 1001) - different app, not spurious
+        assert!(state.check_spurious_focus_change(101).is_none());
+    }
+
+    #[test]
+    fn test_check_spurious_focus_change_same_window() {
+        let ws = MockWindowSystem::new()
+            .with_displays(vec![create_test_display(1, 0.0, 0.0, 1920.0, 1080.0)])
+            .with_windows(vec![create_test_window(
+                100, 1000, "Firefox", 100.0, 100.0, 800.0, 600.0,
+            )])
+            .with_focused(Some(100));
+
+        let mut state = State::new();
+        state.sync_all(&ws);
+
+        // Set focus intent for window 100
+        state.focus_intent = Some(FocusIntent::with_elapsed_ms(100, 1000, 1, 0));
+
+        // Focus change to same window - not spurious
+        assert!(state.check_spurious_focus_change(100).is_none());
+    }
+
+    #[test]
+    fn test_check_spurious_focus_change_suppresses() {
+        let ws = MockWindowSystem::new()
+            .with_displays(vec![create_test_display(1, 0.0, 0.0, 1920.0, 1080.0)])
+            .with_windows(vec![
+                create_test_window(100, 1000, "Firefox", 100.0, 100.0, 800.0, 600.0),
+                create_test_window(101, 1000, "Firefox", 200.0, 200.0, 800.0, 600.0),
+            ])
+            .with_focused(Some(100));
+
+        let mut state = State::new();
+        state.sync_all(&ws);
+
+        // Set focus intent for window 100
+        state.focus_intent = Some(FocusIntent::with_elapsed_ms(100, 1000, 1, 0));
+
+        // Focus change to different window of same app within 200ms - suppress
+        let result = state.check_spurious_focus_change(101);
+        assert_eq!(result, Some(100));
+    }
+
+    #[test]
+    fn test_cross_display_suppression_no_intent() {
+        let ws = MockWindowSystem::new()
+            .with_displays(vec![
+                create_test_display(1, 0.0, 0.0, 1920.0, 1080.0),
+                create_test_display(2, 1920.0, 0.0, 1920.0, 1080.0),
+            ])
+            .with_windows(vec![
+                create_test_window(100, 1000, "Firefox", 100.0, 100.0, 800.0, 600.0),
+                create_test_window(101, 1000, "Firefox", 2000.0, 100.0, 800.0, 600.0),
+            ])
+            .with_focused(Some(100));
+
+        let mut state = State::new();
+        state.sync_all(&ws);
+
+        // No focus intent set
+        assert!(state.focus_intent.is_none());
+
+        // Should return false when no intent
+        assert!(!state.should_suppress_cross_display_tag_switch(101));
+    }
+
+    #[test]
+    fn test_cross_display_suppression_expired() {
+        let ws = MockWindowSystem::new()
+            .with_displays(vec![
+                create_test_display(1, 0.0, 0.0, 1920.0, 1080.0),
+                create_test_display(2, 1920.0, 0.0, 1920.0, 1080.0),
+            ])
+            .with_windows(vec![
+                create_test_window(100, 1000, "Firefox", 100.0, 100.0, 800.0, 600.0),
+                create_test_window(101, 1000, "Firefox", 2000.0, 100.0, 800.0, 600.0),
+            ])
+            .with_focused(Some(100));
+
+        let mut state = State::new();
+        state.sync_all(&ws);
+
+        // Set expired focus intent (>500ms)
+        state.focus_intent = Some(FocusIntent::with_elapsed_ms(100, 1000, 1, 550));
+
+        // Should return false when expired
+        assert!(!state.should_suppress_cross_display_tag_switch(101));
+    }
+
+    #[test]
+    fn test_cross_display_suppression_different_pid() {
+        let ws = MockWindowSystem::new()
+            .with_displays(vec![
+                create_test_display(1, 0.0, 0.0, 1920.0, 1080.0),
+                create_test_display(2, 1920.0, 0.0, 1920.0, 1080.0),
+            ])
+            .with_windows(vec![
+                create_test_window(100, 1000, "Firefox", 100.0, 100.0, 800.0, 600.0),
+                create_test_window(101, 1001, "Safari", 2000.0, 100.0, 800.0, 600.0),
+            ])
+            .with_focused(Some(100));
+
+        let mut state = State::new();
+        state.sync_all(&ws);
+
+        // Set focus intent for Firefox (pid 1000) on display 1
+        state.focus_intent = Some(FocusIntent::with_elapsed_ms(100, 1000, 1, 0));
+
+        // Focus change to Safari (pid 1001) on display 2 - different app
+        assert!(!state.should_suppress_cross_display_tag_switch(101));
+    }
+
+    #[test]
+    fn test_cross_display_suppression_same_display() {
+        let ws = MockWindowSystem::new()
+            .with_displays(vec![create_test_display(1, 0.0, 0.0, 1920.0, 1080.0)])
+            .with_windows(vec![
+                create_test_window(100, 1000, "Firefox", 100.0, 100.0, 800.0, 600.0),
+                create_test_window(101, 1000, "Firefox", 200.0, 200.0, 800.0, 600.0),
+            ])
+            .with_focused(Some(100));
+
+        let mut state = State::new();
+        state.sync_all(&ws);
+
+        // Set focus intent for window 100 on display 1
+        state.focus_intent = Some(FocusIntent::with_elapsed_ms(100, 1000, 1, 0));
+
+        // Focus change to window 101 on same display - not cross-display
+        assert!(!state.should_suppress_cross_display_tag_switch(101));
+    }
+
+    #[test]
+    fn test_cross_display_suppression_suppresses() {
+        let ws = MockWindowSystem::new()
+            .with_displays(vec![
+                create_test_display(1, 0.0, 0.0, 1920.0, 1080.0),
+                create_test_display(2, 1920.0, 0.0, 1920.0, 1080.0),
+            ])
+            .with_windows(vec![
+                create_test_window(100, 1000, "Firefox", 100.0, 100.0, 800.0, 600.0),
+                create_test_window(101, 1000, "Firefox", 2000.0, 100.0, 800.0, 600.0),
+            ])
+            .with_focused(Some(100));
+
+        let mut state = State::new();
+        state.sync_all(&ws);
+
+        // Set focus intent for window 100 on display 1
+        state.focus_intent = Some(FocusIntent::with_elapsed_ms(100, 1000, 1, 0));
+
+        // Focus change to window 101 on display 2 - same app, cross-display
+        assert!(state.should_suppress_cross_display_tag_switch(101));
+    }
+
+    #[test]
+    fn test_cross_display_suppression_between_timeouts() {
+        // Test that cross-display suppression works between 200ms and 500ms
+        // (spurious focus check expires at 200ms, cross-display at 500ms)
+        let ws = MockWindowSystem::new()
+            .with_displays(vec![
+                create_test_display(1, 0.0, 0.0, 1920.0, 1080.0),
+                create_test_display(2, 1920.0, 0.0, 1920.0, 1080.0),
+            ])
+            .with_windows(vec![
+                create_test_window(100, 1000, "Firefox", 100.0, 100.0, 800.0, 600.0),
+                create_test_window(101, 1000, "Firefox", 2000.0, 100.0, 800.0, 600.0),
+            ])
+            .with_focused(Some(100));
+
+        let mut state = State::new();
+        state.sync_all(&ws);
+
+        // Set focus intent at 300ms ago (between 200ms and 500ms)
+        state.focus_intent = Some(FocusIntent::with_elapsed_ms(100, 1000, 1, 300));
+
+        // check_spurious_focus_change should return None (expired at 200ms)
+        assert!(state.check_spurious_focus_change(101).is_none());
+
+        // should_suppress_cross_display_tag_switch should return true (still active at 500ms)
+        assert!(state.should_suppress_cross_display_tag_switch(101));
+    }
+
+    #[test]
+    fn test_should_suppress_rehide_no_intent() {
+        let state = State::new();
+
+        // No focus intent set
+        assert!(!state.should_suppress_rehide(1000));
+    }
+
+    #[test]
+    fn test_should_suppress_rehide_expired() {
+        let mut state = State::new();
+
+        // Set expired focus intent (>200ms)
+        state.focus_intent = Some(FocusIntent::with_elapsed_ms(100, 1000, 1, 250));
+
+        // Should return false when expired
+        assert!(!state.should_suppress_rehide(1000));
+    }
+
+    #[test]
+    fn test_should_suppress_rehide_different_pid() {
+        let mut state = State::new();
+
+        // Set focus intent for pid 1000
+        state.focus_intent = Some(FocusIntent::with_elapsed_ms(100, 1000, 1, 0));
+
+        // Should return false for different pid
+        assert!(!state.should_suppress_rehide(1001));
+    }
+
+    #[test]
+    fn test_should_suppress_rehide_suppresses() {
+        let mut state = State::new();
+
+        // Set focus intent for pid 1000
+        state.focus_intent = Some(FocusIntent::with_elapsed_ms(100, 1000, 1, 0));
+
+        // Should return true for same pid within suppression window
+        assert!(state.should_suppress_rehide(1000));
     }
 }


### PR DESCRIPTION
Add display_id to FocusIntent to detect and suppress cross-display focus redirects. When yashiki focuses a window, macOS may redirect focus to a different window of the same app on another display, causing unwanted tag switches.

- Add display_id field to FocusIntent
- Add should_suppress_cross_display_tag_switch() with 500ms window
- Check for cross-display redirect in switch_tag_if_needed()
- Add comprehensive FocusIntent unit tests