### PR TITLE
fix: use effective_focused_display() to protect all commands from spurious focus redirect

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -505,8 +505,11 @@ If user clicks a different window of the same app within 200ms of a yashiki focu
 2. This scenario is rare in practice
 3. The alternative (focus jumping between displays) is much worse UX
 
+**Command Display Resolution:**
+`effective_focused_display()` returns `focus_intent.display_id` during the cross-display suppression window (500ms), falling back to `focused_display`. Used by `get_target_display()`, `focus_output()`, `view_tags_last()`, and `get_tag_view_display()` to prevent spurious macOS focus redirects from misdirecting commands.
+
 **Related code:**
-- `core/state/mod.rs`: `FocusIntent`, `set_focus_intent()`, `should_suppress_rehide()`, `check_spurious_focus_change()`
+- `core/state/mod.rs`: `FocusIntent`, `set_focus_intent()`, `should_suppress_rehide()`, `check_spurious_focus_change()`, `effective_focused_display()`, `get_target_display()`
 - `core/state/sync.rs`: `detect_rehide_moves()` - uses `should_suppress_rehide()` to skip re-hide
 - `app/effects.rs`: `Effect::FocusWindow` - calls `set_focus_intent()`
 - `app/focus.rs`: `focus_visible_window_if_needed()` - calls `set_focus_intent()`

--- a/yashiki/src/app/dispatch.rs
+++ b/yashiki/src/app/dispatch.rs
@@ -52,7 +52,7 @@ fn get_tag_view_display(cmd: &Command, state: &State) -> Option<DisplayId> {
         Command::TagView { output, .. } | Command::TagToggle { output, .. } => {
             state.get_target_display(output.as_ref()).ok()
         }
-        Command::TagViewLast => Some(state.focused_display),
+        Command::TagViewLast => Some(state.effective_focused_display()),
         _ => None,
     }
 }

--- a/yashiki/src/core/state/display.rs
+++ b/yashiki/src/core/state/display.rs
@@ -190,9 +190,8 @@ pub fn focus_output(state: &mut State, direction: OutputDirection) -> Option<Foc
     let mut display_ids: Vec<_> = state.displays.keys().copied().collect();
     display_ids.sort();
 
-    let current_idx = display_ids
-        .iter()
-        .position(|&id| id == state.focused_display)?;
+    let effective_display = state.effective_focused_display();
+    let current_idx = display_ids.iter().position(|&id| id == effective_display)?;
 
     let next_idx = match direction {
         OutputDirection::Next => (current_idx + 1) % display_ids.len(),

--- a/yashiki/src/core/state/mod.rs
+++ b/yashiki/src/core/state/mod.rs
@@ -467,6 +467,18 @@ impl State {
         }
     }
 
+    /// Returns the effective focused display, considering FocusIntent.
+    /// During cross-display suppression window (500ms), returns intent's display_id
+    /// to prevent spurious macOS focus redirects from misdirecting commands.
+    pub fn effective_focused_display(&self) -> DisplayId {
+        if let Some(intent) = &self.focus_intent {
+            if intent.is_active_for_cross_display() {
+                return intent.display_id;
+            }
+        }
+        self.focused_display
+    }
+
     pub fn get_target_display(
         &self,
         output: Option<&OutputSpecifier>,
@@ -475,7 +487,7 @@ impl State {
             Some(spec) => self
                 .resolve_output(spec)
                 .ok_or_else(|| format!("Output not found: {:?}", spec)),
-            None => Ok(self.focused_display),
+            None => Ok(self.effective_focused_display()),
         }
     }
 
@@ -3320,5 +3332,120 @@ mod tests {
 
         // Should return true for same pid within suppression window
         assert!(state.should_suppress_rehide(1000));
+    }
+
+    // get_target_display tests
+
+    #[test]
+    fn test_get_target_display_uses_focus_intent_when_active() {
+        let ws = MockWindowSystem::new()
+            .with_displays(vec![
+                create_test_display(1, 0.0, 0.0, 1920.0, 1080.0),
+                create_test_display(2, 1920.0, 0.0, 1920.0, 1080.0),
+            ])
+            .with_windows(vec![
+                create_test_window(100, 1000, "Firefox", 100.0, 100.0, 800.0, 600.0),
+                create_test_window(101, 1000, "Firefox", 2020.0, 100.0, 800.0, 600.0),
+            ])
+            .with_focused(Some(100));
+
+        let mut state = State::new();
+        state.sync_all(&ws);
+
+        // Simulate: FocusIntent was set for window 100 on display 1
+        // but focused_display got spuriously changed to 2
+        state.focus_intent = Some(FocusIntent::new(100, 1000, 1));
+        state.focused_display = 2;
+
+        // get_target_display should return intent's display_id (1), not focused_display (2)
+        assert_eq!(state.get_target_display(None).unwrap(), 1);
+    }
+
+    #[test]
+    fn test_get_target_display_uses_focused_display_when_intent_expired() {
+        let ws = MockWindowSystem::new()
+            .with_displays(vec![
+                create_test_display(1, 0.0, 0.0, 1920.0, 1080.0),
+                create_test_display(2, 1920.0, 0.0, 1920.0, 1080.0),
+            ])
+            .with_windows(vec![create_test_window(
+                100, 1000, "Firefox", 100.0, 100.0, 800.0, 600.0,
+            )])
+            .with_focused(Some(100));
+
+        let mut state = State::new();
+        state.sync_all(&ws);
+
+        // Set expired focus intent (501ms > 500ms cross-display threshold)
+        state.focus_intent = Some(FocusIntent::with_elapsed_ms(100, 1000, 1, 501));
+        state.focused_display = 2;
+
+        // Should return focused_display since intent expired
+        assert_eq!(state.get_target_display(None).unwrap(), 2);
+    }
+
+    #[test]
+    fn test_get_target_display_explicit_output_ignores_intent() {
+        let ws = MockWindowSystem::new()
+            .with_displays(vec![
+                create_test_display(1, 0.0, 0.0, 1920.0, 1080.0),
+                create_test_display(2, 1920.0, 0.0, 1920.0, 1080.0),
+            ])
+            .with_windows(vec![create_test_window(
+                100, 1000, "Firefox", 100.0, 100.0, 800.0, 600.0,
+            )])
+            .with_focused(Some(100));
+
+        let mut state = State::new();
+        state.sync_all(&ws);
+
+        state.focus_intent = Some(FocusIntent::new(100, 1000, 1));
+        state.focused_display = 1;
+
+        // Explicit output specifier should be used, ignoring intent
+        let output = OutputSpecifier::Id(2);
+        assert_eq!(state.get_target_display(Some(&output)).unwrap(), 2);
+    }
+
+    #[test]
+    fn test_get_target_display_no_intent() {
+        let ws = MockWindowSystem::new()
+            .with_displays(vec![
+                create_test_display(1, 0.0, 0.0, 1920.0, 1080.0),
+                create_test_display(2, 1920.0, 0.0, 1920.0, 1080.0),
+            ])
+            .with_windows(vec![])
+            .with_focused(None);
+
+        let mut state = State::new();
+        state.sync_all(&ws);
+        state.focused_display = 2;
+
+        // No intent - should use focused_display
+        assert!(state.focus_intent.is_none());
+        assert_eq!(state.get_target_display(None).unwrap(), 2);
+    }
+
+    #[test]
+    fn test_effective_focused_display_with_active_intent() {
+        let mut state = State::new();
+        state.focused_display = 2;
+        state.focus_intent = Some(FocusIntent::new(100, 1000, 1));
+        assert_eq!(state.effective_focused_display(), 1);
+    }
+
+    #[test]
+    fn test_effective_focused_display_with_expired_intent() {
+        let mut state = State::new();
+        state.focused_display = 2;
+        state.focus_intent = Some(FocusIntent::with_elapsed_ms(100, 1000, 1, 501));
+        assert_eq!(state.effective_focused_display(), 2);
+    }
+
+    #[test]
+    fn test_effective_focused_display_no_intent() {
+        let mut state = State::new();
+        state.focused_display = 3;
+        assert_eq!(state.effective_focused_display(), 3);
     }
 }

--- a/yashiki/src/core/state/tags.rs
+++ b/yashiki/src/core/state/tags.rs
@@ -62,7 +62,8 @@ pub fn toggle_tags_on_display(
 }
 
 pub fn view_tags_last(state: &mut State) -> Vec<WindowMove> {
-    let Some(disp) = state.displays.get_mut(&state.focused_display) else {
+    let display_id = state.effective_focused_display();
+    let Some(disp) = state.displays.get_mut(&display_id) else {
         return vec![];
     };
     if disp.visible_tags == disp.previous_visible_tags {
@@ -70,7 +71,7 @@ pub fn view_tags_last(state: &mut State) -> Vec<WindowMove> {
     }
     tracing::info!(
         "View tags last on display {}: {} -> {}, layout: {:?} -> {:?}",
-        state.focused_display,
+        display_id,
         disp.visible_tags.mask(),
         disp.previous_visible_tags.mask(),
         disp.current_layout,
@@ -78,7 +79,7 @@ pub fn view_tags_last(state: &mut State) -> Vec<WindowMove> {
     );
     std::mem::swap(&mut disp.visible_tags, &mut disp.previous_visible_tags);
     std::mem::swap(&mut disp.current_layout, &mut disp.previous_layout);
-    compute_layout_changes_for_display(state, state.focused_display)
+    compute_layout_changes_for_display(state, display_id)
 }
 
 pub fn move_focused_to_tags(state: &mut State, tags: u32) -> Vec<WindowMove> {


### PR DESCRIPTION
output-focus, view-tags-last, and get-tag-view-display were directly referencing state.focused_display, bypassing the FocusIntent cross-display suppression. Extract effective_focused_display() helper from get_target_display() and use it in all call sites that need display resolution.