### PR TITLE
fix: revert focused_display on spurious focus redirect to prevent permanent state corruption

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -494,6 +494,8 @@ This commonly happens with multi-window apps like Firefox across multiple displa
 
 2. **Re-hide suppression**: Within the suppression window, hidden windows of the same app are not re-hidden when macOS moves them. This prevents focus operations from triggering unnecessary window movements.
 
+3. **`focused_display` revert**: Both suppression paths (`check_spurious_focus_change` in app.rs, `should_suppress_cross_display_tag_switch` in focus.rs) revert `focused_display` to its pre-redirect value, ensuring subsequent commands target the correct display even after the 500ms suppression window expires.
+
 **Design principles:**
 - Single source of truth: `FocusIntent` lives in `State`
 - Unified call sites: `set_focus_intent()` called in `Effect::FocusWindow` and `focus_visible_window_if_needed()`

--- a/yashiki/src/app.rs
+++ b/yashiki/src/app.rs
@@ -786,11 +786,12 @@ impl App {
                     Event::FocusedWindowChanged | Event::ApplicationActivated { .. }
                 );
 
-                // Capture previous focused window before handle_event updates it
-                let prev_focused = if is_focus_event {
-                    Some(ctx.state.borrow().focused)
+                // Capture previous focused window and display before handle_event updates it
+                let (prev_focused, prev_focused_display) = if is_focus_event {
+                    let s = ctx.state.borrow();
+                    (Some(s.focused), Some(s.focused_display))
                 } else {
-                    None
+                    (None, None)
                 };
 
                 // For ApplicationActivated, sync windows if none exist for this pid.
@@ -873,7 +874,18 @@ impl App {
                                 intended_id
                             );
                             ctx.window_manipulator.focus_window(intended_id, pid);
-                            ctx.state.borrow_mut().set_focused(Some(intended_id));
+                            let mut state = ctx.state.borrow_mut();
+                            state.set_focused(Some(intended_id));
+                            if let Some(prev_display) = prev_focused_display {
+                                if state.focused_display != prev_display {
+                                    tracing::debug!(
+                                        "Reverting focused_display: {} -> {}",
+                                        state.focused_display,
+                                        prev_display
+                                    );
+                                    state.focused_display = prev_display;
+                                }
+                            }
                             // Skip further focus handling - don't switch tags
                             continue;
                         }

--- a/yashiki/src/app/focus.rs
+++ b/yashiki/src/app/focus.rs
@@ -102,6 +102,18 @@ pub fn switch_tag_for_focused_window(state: &RefCell<State>) -> Option<Vec<Windo
             "Skipping tag switch for window {} - detected cross-display focus redirect",
             focused_id
         );
+        let mut s = state.borrow_mut();
+        if let Some(intent) = &s.focus_intent {
+            let intended_display = intent.display_id;
+            if s.focused_display != intended_display {
+                tracing::debug!(
+                    "Reverting focused_display: {} -> {}",
+                    s.focused_display,
+                    intended_display
+                );
+                s.focused_display = intended_display;
+            }
+        }
         return None;
     }
 


### PR DESCRIPTION
When macOS redirects focus to a different window of the same app on another display, sync_focused_window_with_hint() updates focused_display before the suppression logic detects the redirect. Previously, focused_display remained wrong after the 500ms suppression window expired.

Now both suppression paths revert focused_display:
- check_spurious_focus_change (app.rs, 0-200ms): reverts to pre-event value
- should_suppress_cross_display_tag_switch (focus.rs, 200-500ms): reverts to FocusIntent.display_id

Complements the previous effective_focused_display() fix which only protects commands within the 500ms window.