### PR TITLE
Add --current-tags flag to output-send command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,7 +110,7 @@ yashiki window-toggle-fullscreen
 yashiki window-toggle-float
 yashiki window-close
 yashiki output-focus next|prev
-yashiki output-send next|prev
+yashiki output-send [--current-tags] next|prev  # --current-tags: make window visible immediately on target display
 yashiki retile [--output N]
 yashiki layout-set-default tatami
 yashiki layout-set [--tags N] [--output N] byobu

--- a/yashiki-ipc/src/command.rs
+++ b/yashiki-ipc/src/command.rs
@@ -624,6 +624,7 @@ pub enum Command {
     },
     OutputSend {
         direction: OutputDirection,
+        current_tags: bool,
     },
 
     // Layout operations

--- a/yashiki/src/app/command.rs
+++ b/yashiki/src/app/command.rs
@@ -305,8 +305,11 @@ pub fn process_command(
         }
 
         // Send to output - returns displays that need retiling
-        Command::OutputSend { direction } => {
-            if let Some(result) = state.send_to_output(*direction) {
+        Command::OutputSend {
+            direction,
+            current_tags,
+        } => {
+            if let Some(result) = state.send_to_output(*direction, *current_tags) {
                 CommandResult::ok_with_effects(vec![
                     Effect::ApplyWindowMoves(result.window_moves),
                     Effect::RetileDisplays(vec![

--- a/yashiki/src/core/state/display.rs
+++ b/yashiki/src/core/state/display.rs
@@ -220,7 +220,11 @@ pub fn focus_output(state: &mut State, direction: OutputDirection) -> Option<Foc
     }
 }
 
-pub fn send_to_output(state: &mut State, direction: OutputDirection) -> Option<SendToOutputResult> {
+pub fn send_to_output(
+    state: &mut State,
+    direction: OutputDirection,
+    current_tags: bool,
+) -> Option<SendToOutputResult> {
     let focused_id = state.focused?;
 
     if state.displays.len() <= 1 {
@@ -247,6 +251,7 @@ pub fn send_to_output(state: &mut State, direction: OutputDirection) -> Option<S
     let target_display = state.displays.get(&target_display_id)?;
     let target_frame_x = target_display.frame.x;
     let target_frame_y = target_display.frame.y;
+    let target_visible_tags = target_display.visible_tags;
 
     // Update window's display_id and frame position
     let window = state.windows.get_mut(&focused_id)?;
@@ -259,6 +264,18 @@ pub fn send_to_output(state: &mut State, direction: OutputDirection) -> Option<S
     window.display_id = target_display_id;
     // User intentionally moved the window - clear orphan state
     window.orphaned_from = None;
+
+    // If --current-tags is set, update window tags to match target display's visible tags
+    if current_tags {
+        tracing::debug!(
+            "Setting window {} tags from {:032b} to {:032b}",
+            window.id,
+            window.tags.mask(),
+            target_visible_tags.mask()
+        );
+        window.tags = target_visible_tags;
+    }
+
     // Set frame to target display's position (will be overwritten by retile if visible,
     // or saved to saved_frame if hidden - either way, correct display context)
     window.frame.x = target_frame_x;

--- a/yashiki/src/core/state/display.rs
+++ b/yashiki/src/core/state/display.rs
@@ -267,8 +267,8 @@ pub fn send_to_output(
 
     // If --current-tags is set, update window tags to match target display's visible tags
     if current_tags {
-        tracing::debug!(
-            "Setting window {} tags from {:032b} to {:032b}",
+        tracing::info!(
+            "Setting window {} tags from {:?} to {:?}",
             window.id,
             window.tags.mask(),
             target_visible_tags.mask()

--- a/yashiki/src/core/state/mod.rs
+++ b/yashiki/src/core/state/mod.rs
@@ -625,8 +625,12 @@ impl State {
         focus_output(self, direction)
     }
 
-    pub fn send_to_output(&mut self, direction: OutputDirection) -> Option<SendToOutputResult> {
-        send_to_output(self, direction)
+    pub fn send_to_output(
+        &mut self,
+        direction: OutputDirection,
+        current_tags: bool,
+    ) -> Option<SendToOutputResult> {
+        send_to_output(self, direction, current_tags)
     }
 
     // Layout operations - delegated to state/layout.rs
@@ -1833,7 +1837,7 @@ mod tests {
         assert_eq!(state.displays.get(&1).unwrap().visible_tags.mask(), 1);
         assert_eq!(state.displays.get(&2).unwrap().visible_tags.mask(), 1);
 
-        let result = state.send_to_output(OutputDirection::Next);
+        let result = state.send_to_output(OutputDirection::Next, false);
         assert!(result.is_some());
 
         let result = result.unwrap();
@@ -1872,7 +1876,7 @@ mod tests {
         state.displays.get_mut(&1).unwrap().visible_tags = Tag::new(2);
         state.displays.get_mut(&2).unwrap().visible_tags = Tag::new(1);
 
-        let result = state.send_to_output(OutputDirection::Next);
+        let result = state.send_to_output(OutputDirection::Next, false);
         assert!(result.is_some());
 
         let result = result.unwrap();
@@ -1909,7 +1913,7 @@ mod tests {
         assert!(state.displays.get(&1).unwrap().window_order.contains(&100));
         assert!(state.displays.get(&2).unwrap().window_order.contains(&101));
 
-        let result = state.send_to_output(OutputDirection::Next);
+        let result = state.send_to_output(OutputDirection::Next, false);
         assert!(result.is_some());
 
         // Window 100 should be removed from display 1's order and added to display 2's order
@@ -1944,7 +1948,7 @@ mod tests {
         assert!(state.windows.get(&100).unwrap().is_hidden());
 
         // Now send to output - target display shows tag 2, so window should become visible
-        let result = state.send_to_output(OutputDirection::Next);
+        let result = state.send_to_output(OutputDirection::Next, false);
         assert!(result.is_some());
 
         let result = result.unwrap();
@@ -1980,7 +1984,7 @@ mod tests {
         state.sync_all(&ws);
         state.focused_display = 1;
 
-        let result = state.send_to_output(OutputDirection::Next);
+        let result = state.send_to_output(OutputDirection::Next, false);
         assert!(result.is_some());
 
         // Window moved to display 2
@@ -2295,7 +2299,7 @@ mod tests {
         state.windows.get_mut(&100).unwrap().orphaned_from = Some(2);
 
         // User sends window to next output
-        let result = state.send_to_output(OutputDirection::Next);
+        let result = state.send_to_output(OutputDirection::Next, false);
         assert!(result.is_some());
 
         // orphaned_from should be cleared (user intentionally moved it)
@@ -2304,6 +2308,43 @@ mod tests {
     }
 
     #[test]
+    fn test_send_to_output_with_current_tags() {
+        // Test the --current-tags flag functionality
+        // Window on display 1 with tag 2, should be updated to target display's visible tags
+        let ws = MockWindowSystem::new()
+            .with_displays(vec![
+                create_test_display(1, 0.0, 0.0, 1920.0, 1080.0),
+                create_test_display(2, 1920.0, 0.0, 1920.0, 1080.0),
+            ])
+            .with_windows(vec![create_test_window(
+                100, 1000, "Safari", 100.0, 100.0, 800.0, 600.0,
+            )])
+            .with_focused(Some(100));
+
+        let mut state = State::new();
+        state.sync_all(&ws);
+
+        // Set window to tag 2, display 1 shows tag 2, display 2 shows tag 3
+        state.windows.get_mut(&100).unwrap().tags = Tag::new(2);
+        state.displays.get_mut(&1).unwrap().visible_tags = Tag::new(2);
+        state.displays.get_mut(&2).unwrap().visible_tags = Tag::new(3);
+
+        // Send to next output with current_tags=true
+        let result = state.send_to_output(OutputDirection::Next, true);
+        assert!(result.is_some());
+
+        // Window should now have tag 3 (target display's visible tags)
+        assert_eq!(
+            state.windows.get(&100).unwrap().tags.mask(),
+            Tag::new(3).mask()
+        );
+        assert_eq!(state.windows.get(&100).unwrap().display_id, 2);
+        // Window should be visible now (no hide moves)
+        assert!(result.unwrap().window_moves.is_empty());
+    }
+
+    #[test]
+
     fn test_rapid_display_reconnect_preserves_window_position() {
         // Simulates sleep/wake: display removed then quickly re-added
         // Window should end up on its original display

--- a/yashiki/src/main.rs
+++ b/yashiki/src/main.rs
@@ -250,6 +250,9 @@ struct OutputSendCmd {
     /// direction: next, prev
     #[argh(positional)]
     direction: String,
+    /// use destination output's current visible tags for the window
+    #[argh(switch, long = "current-tags")]
+    current_tags: bool,
 }
 
 /// Re-apply the current layout
@@ -879,6 +882,7 @@ fn to_command(subcmd: SubCommand) -> Result<Command> {
         }),
         SubCommand::OutputSend(cmd) => Ok(Command::OutputSend {
             direction: parse_output_direction(&cmd.direction)?,
+            current_tags: cmd.current_tags,
         }),
         SubCommand::Retile(cmd) => Ok(Command::Retile {
             output: parse_output_specifier(cmd.output),
@@ -1149,6 +1153,7 @@ fn parse_command(args: &[String]) -> Result<Command> {
             let cmd: OutputSendCmd = from_argh(cmd_name, &cmd_args)?;
             Ok(Command::OutputSend {
                 direction: parse_output_direction(&cmd.direction)?,
+                current_tags: cmd.current_tags,
             })
         }
         "retile" => {


### PR DESCRIPTION
Adds a `--current-tags` flag to `yashiki output-send` that automatically updates the window's tags to match the destination display's visible tags, making the window immediately visible on the target display. Inspiration was taken from riverctl, which provides a `-current-tags` flag when doing `send-to-output`.

- Add --current-tags boolean flag to OutputSendCmd struct
- Update OutputSend command enum to include current_tags field
- Modify send_to_output() to update window tags when flag is set
- Update command dispatcher to pass flag through to state
- Add comprehensive test for the new functionality
- Update CLAUDE.md documentation