### PR TITLE
docs: add workaround setting for Firefox

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -551,6 +551,7 @@ yashiki rule-add --app-id com.mitchellh.ghostty --fullscreen-button disabled ign
 ```sh
 # Firefox popups
 yashiki rule-add --app-id org.mozilla.firefox --subrole AXUnknown ignore
+yashiki rule-add --app-id org.mozilla.firefox --subrole none ignore
 
 # Generic fix for all popups
 yashiki rule-add --subrole AXUnknown ignore

--- a/docs/workarounds.md
+++ b/docs/workarounds.md
@@ -49,6 +49,9 @@ Firefox creates temporary popup windows (dropdowns, autocomplete, etc.) that can
 # Ignore popup windows with AXUnknown subrole (dropdowns, autocomplete, etc.)
 yashiki rule-add --app-id org.mozilla.firefox --subrole AXUnknown ignore
 
+# Some popup windows added with none subrole
+yashiki rule-add --app-id org.mozilla.firefox --subrole none ignore
+
 # Float PiP (Picture-in-Picture) and other floating-level windows
 yashiki rule-add --app-id org.mozilla.firefox --window-level floating float
 ```


### PR DESCRIPTION
I mainly use Firefox Developer Edition so I created init file according to example and workarounds.

```sh
#!/bin/sh

# Some settings...

# Workarounds
yashiki rule-add --app-id "org.mozilla.firefoxdeveloperedition" --subrole AXUnknown ignore
```

But flickering still works. As a result I found some popup windows added with ax_id=None, 
subrole=None, level=0. I used Firefox in recording but developer edition and nightly also has same issue.

https://github.com/user-attachments/assets/c72b6944-802f-44ae-875c-18f0a6e38dbd

So I added workaround setting to docs.

In addition input source makes display flickering only Firefox Developer Edition but I can't reproduce in my environment so I will just share it in this description.

```sh
#!/bin/sh

# Ignore change input source (Firefox Developer Edition only)
yashiki rule-add --app-id "org.mozilla.firefoxdeveloperedition" --subrole AXDialog --window-level floating ignore
```

https://github.com/user-attachments/assets/1455ff67-0d9a-4f6b-befa-5814832ebef4

I'm sorry I'm not good at English so I sometimes make writing mistakes.
And thanks for developing great project!!