### PR TITLE
fix: suppress cross-PID spurious focus bounce on tag switch

### DIFF
--- a/yashiki/src/app.rs
+++ b/yashiki/src/app.rs
@@ -1033,6 +1033,47 @@ impl App {
                             emit_state_change_events(&ctx.event_emitter, &ctx.state, &pre_state);
                             continue;
                         }
+
+                        // Check for cross-PID spurious focus change
+                        // (focus bounced to a hidden window of a different app, e.g., Dia browser)
+                        let cross_pid_refocus_info = ctx
+                            .state
+                            .borrow()
+                            .should_suppress_tag_switch_for_hidden_window(focused_id)
+                            .then(|| {
+                                let s = ctx.state.borrow();
+                                s.focus_intent.as_ref().and_then(|intent| {
+                                    s.windows
+                                        .get(&intent.window_id)
+                                        .map(|w| (intent.window_id, w.pid, intent.display_id))
+                                })
+                            })
+                            .flatten();
+
+                        if let Some((intended_id, _pid, intended_display)) = cross_pid_refocus_info
+                        {
+                            tracing::info!(
+                                "Suppressing cross-PID spurious focus change (intended: {})",
+                                intended_id
+                            );
+                            // Only revert internal state — do NOT call refocus_window here.
+                            // Refocusing triggers new FocusedWindowChanged events from macOS,
+                            // creating an infinite focus-bounce loop with apps like Dia browser.
+                            {
+                                let mut state = ctx.state.borrow_mut();
+                                state.set_focused(Some(intended_id));
+                                if state.focused_display != intended_display {
+                                    tracing::debug!(
+                                        "Reverting focused_display: {} -> {}",
+                                        state.focused_display,
+                                        intended_display
+                                    );
+                                    state.focused_display = intended_display;
+                                }
+                            }
+                            emit_state_change_events(&ctx.event_emitter, &ctx.state, &pre_state);
+                            continue;
+                        }
                     }
 
                     if let Some(focused_id) = focused_id {

--- a/yashiki/src/app.rs
+++ b/yashiki/src/app.rs
@@ -1045,12 +1045,12 @@ impl App {
                                 s.focus_intent.as_ref().and_then(|intent| {
                                     s.windows
                                         .get(&intent.window_id)
-                                        .map(|w| (intent.window_id, w.pid, intent.display_id))
+                                        .map(|_| (intent.window_id, intent.display_id))
                                 })
                             })
                             .flatten();
 
-                        if let Some((intended_id, _pid, intended_display)) = cross_pid_refocus_info
+                        if let Some((intended_id, intended_display)) = cross_pid_refocus_info
                         {
                             tracing::info!(
                                 "Suppressing cross-PID spurious focus change (intended: {})",

--- a/yashiki/src/app.rs
+++ b/yashiki/src/app.rs
@@ -1050,8 +1050,7 @@ impl App {
                             })
                             .flatten();
 
-                        if let Some((intended_id, intended_display)) = cross_pid_refocus_info
-                        {
+                        if let Some((intended_id, intended_display)) = cross_pid_refocus_info {
                             tracing::info!(
                                 "Suppressing cross-PID spurious focus change (intended: {})",
                                 intended_id
@@ -1059,6 +1058,7 @@ impl App {
                             // Only revert internal state — do NOT call refocus_window here.
                             // Refocusing triggers new FocusedWindowChanged events from macOS,
                             // creating an infinite focus-bounce loop with apps like Dia browser.
+                            // Trade-off: macOS keyboard focus may temporarily remain on the previous app.
                             {
                                 let mut state = ctx.state.borrow_mut();
                                 state.set_focused(Some(intended_id));

--- a/yashiki/src/core/state/mod.rs
+++ b/yashiki/src/core/state/mod.rs
@@ -3462,6 +3462,144 @@ mod tests {
         assert!(state.should_suppress_cross_display_tag_switch(101));
     }
 
+    // should_suppress_tag_switch_for_hidden_window tests
+
+    #[test]
+    fn test_suppress_hidden_window_no_intent() {
+        let ws = MockWindowSystem::new()
+            .with_displays(vec![create_test_display(1, 0.0, 0.0, 1920.0, 1080.0)])
+            .with_windows(vec![
+                create_test_window(100, 1000, "Dia", 100.0, 100.0, 800.0, 600.0),
+                create_test_window(101, 1001, "cmux", 200.0, 200.0, 800.0, 600.0),
+            ])
+            .with_focused(Some(100));
+
+        let mut state = State::new();
+        state.sync_all(&ws);
+
+        // No focus intent set
+        assert!(state.focus_intent.is_none());
+        assert!(!state.should_suppress_tag_switch_for_hidden_window(101));
+    }
+
+    #[test]
+    fn test_suppress_hidden_window_expired() {
+        let ws = MockWindowSystem::new()
+            .with_displays(vec![create_test_display(1, 0.0, 0.0, 1920.0, 1080.0)])
+            .with_windows(vec![
+                create_test_window(100, 1000, "Dia", 100.0, 100.0, 800.0, 600.0),
+                create_test_window(101, 1001, "cmux", 200.0, 200.0, 800.0, 600.0),
+            ])
+            .with_focused(Some(100));
+
+        let mut state = State::new();
+        state.sync_all(&ws);
+
+        // Make window 101 hidden
+        state.windows.get_mut(&101).unwrap().saved_frame = Some(Rect {
+            x: 200,
+            y: 200,
+            width: 800,
+            height: 600,
+        });
+
+        // Set expired focus intent (>200ms)
+        state.focus_intent = Some(FocusIntent::with_elapsed_ms(100, 1000, 1, 250));
+
+        assert!(!state.should_suppress_tag_switch_for_hidden_window(101));
+    }
+
+    #[test]
+    fn test_suppress_hidden_window_same_pid() {
+        let ws = MockWindowSystem::new()
+            .with_displays(vec![create_test_display(1, 0.0, 0.0, 1920.0, 1080.0)])
+            .with_windows(vec![
+                create_test_window(100, 1000, "Firefox", 100.0, 100.0, 800.0, 600.0),
+                create_test_window(101, 1000, "Firefox", 200.0, 200.0, 800.0, 600.0),
+            ])
+            .with_focused(Some(100));
+
+        let mut state = State::new();
+        state.sync_all(&ws);
+
+        // Make window 101 hidden
+        state.windows.get_mut(&101).unwrap().saved_frame = Some(Rect {
+            x: 200,
+            y: 200,
+            width: 800,
+            height: 600,
+        });
+
+        // Same PID - should be handled by check_spurious_focus_change instead
+        state.focus_intent = Some(FocusIntent::with_elapsed_ms(100, 1000, 1, 0));
+
+        assert!(!state.should_suppress_tag_switch_for_hidden_window(101));
+    }
+
+    #[test]
+    fn test_suppress_hidden_window_intended_window() {
+        let ws = MockWindowSystem::new()
+            .with_displays(vec![create_test_display(1, 0.0, 0.0, 1920.0, 1080.0)])
+            .with_windows(vec![create_test_window(
+                100, 1000, "Dia", 100.0, 100.0, 800.0, 600.0,
+            )])
+            .with_focused(Some(100));
+
+        let mut state = State::new();
+        state.sync_all(&ws);
+
+        // Focus went to the intended window itself - normal case, don't suppress
+        state.focus_intent = Some(FocusIntent::with_elapsed_ms(100, 1000, 1, 0));
+
+        assert!(!state.should_suppress_tag_switch_for_hidden_window(100));
+    }
+
+    #[test]
+    fn test_suppress_hidden_window_cross_pid_visible() {
+        let ws = MockWindowSystem::new()
+            .with_displays(vec![create_test_display(1, 0.0, 0.0, 1920.0, 1080.0)])
+            .with_windows(vec![
+                create_test_window(100, 1000, "Dia", 100.0, 100.0, 800.0, 600.0),
+                create_test_window(101, 1001, "cmux", 200.0, 200.0, 800.0, 600.0),
+            ])
+            .with_focused(Some(100));
+
+        let mut state = State::new();
+        state.sync_all(&ws);
+
+        // Window 101 is visible (no saved_frame) - don't suppress
+        state.focus_intent = Some(FocusIntent::with_elapsed_ms(100, 1000, 1, 0));
+
+        assert!(!state.should_suppress_tag_switch_for_hidden_window(101));
+    }
+
+    #[test]
+    fn test_suppress_hidden_window_cross_pid_hidden() {
+        let ws = MockWindowSystem::new()
+            .with_displays(vec![create_test_display(1, 0.0, 0.0, 1920.0, 1080.0)])
+            .with_windows(vec![
+                create_test_window(100, 1000, "Dia", 100.0, 100.0, 800.0, 600.0),
+                create_test_window(101, 1001, "cmux", 200.0, 200.0, 800.0, 600.0),
+            ])
+            .with_focused(Some(100));
+
+        let mut state = State::new();
+        state.sync_all(&ws);
+
+        // Make window 101 hidden (simulates tag switch hiding cmux)
+        state.windows.get_mut(&101).unwrap().saved_frame = Some(Rect {
+            x: 200,
+            y: 200,
+            width: 800,
+            height: 600,
+        });
+
+        // Cross-PID + hidden window within suppression window → suppress
+        state.focus_intent = Some(FocusIntent::with_elapsed_ms(100, 1000, 1, 0));
+
+        assert!(state.should_suppress_tag_switch_for_hidden_window(101));
+    }
+
     #[test]
     fn test_should_suppress_rehide_no_intent() {
         let state = State::new();

--- a/yashiki/src/core/state/mod.rs
+++ b/yashiki/src/core/state/mod.rs
@@ -419,6 +419,50 @@ impl State {
         false
     }
 
+    /// Check if automatic tag switching should be suppressed for a hidden window
+    /// that received focus while FocusIntent is active.
+    ///
+    /// This handles cross-PID spurious focus changes: when yashiki focuses window A
+    /// and macOS redirects focus to a hidden window B of a DIFFERENT app within the
+    /// suppression window. Without this, the auto-tag-switch would undo the tag switch.
+    pub fn should_suppress_tag_switch_for_hidden_window(&self, new_focused_id: WindowId) -> bool {
+        let Some(intent) = self.focus_intent.as_ref() else {
+            return false;
+        };
+        if !intent.is_active() {
+            return false;
+        }
+
+        // Don't suppress if focus went to the intended window (normal case)
+        if new_focused_id == intent.window_id {
+            return false;
+        }
+
+        // Same-PID cases are already handled by check_spurious_focus_change
+        // and should_suppress_cross_display_tag_switch
+        let Some(new_window) = self.windows.get(&new_focused_id) else {
+            return false;
+        };
+        if new_window.pid == intent.pid {
+            return false;
+        }
+
+        // Cross-PID focus change to a hidden window within suppression window
+        // is almost certainly spurious macOS behavior
+        if new_window.is_hidden() {
+            tracing::debug!(
+                "Suppressing cross-PID tag switch: window {} (pid {}) is hidden, intended: window {} (pid {})",
+                new_focused_id,
+                new_window.pid,
+                intent.window_id,
+                intent.pid
+            );
+            return true;
+        }
+
+        false
+    }
+
     /// Remove all windows belonging to a terminated process.
     /// Used when AppTerminated event is received - bypasses AX API checks since
     /// the process is confirmed terminated via NSWorkspace notification.


### PR DESCRIPTION
  When switching to a tag containing certain Chromium-based apps (e.g., Dia
  browser), macOS sends a spurious FocusedWindowChanged event ~90ms later
  pointing back to the previously focused (now hidden) window of a different
  app. The auto-tag-switch logic interpreted this as a user-initiated external
  focus change and reverted the tag switch.

  The existing FocusIntent suppression only handled same-PID focus redirects.
  This adds cross-PID suppression: when FocusIntent is active and focus
  bounces to a hidden window of a different app, the event is suppressed
  without calling refocus_window (which would create an infinite bounce loop).

---- 

fixes #164 