### PR TITLE
fix: re-set main window after AXFrontmost to fix focus on background-app windows

### DIFF
--- a/yashiki/src/platform.rs
+++ b/yashiki/src/platform.rs
@@ -349,6 +349,34 @@ impl WindowManipulator for MacOSWindowManipulator {
                                 activate_application(pid);
                             }
                         }
+                        // Firefox restores its last-focused window as key on AXFrontmost,
+                        // ignoring the set_main/raise above. Re-issue them so the requested
+                        // window becomes key. No-op for apps that already respected the
+                        // earlier calls.
+                        match ax_win.set_main(true) {
+                            Ok(()) => tracing::debug!(
+                                "Re-set main window {} (pid {}) after AXFrontmost",
+                                window_id,
+                                pid
+                            ),
+                            Err(e) => tracing::warn!(
+                                "Failed to re-set main window {} after AXFrontmost: {}",
+                                window_id,
+                                e
+                            ),
+                        }
+                        match ax_win.raise() {
+                            Ok(()) => tracing::debug!(
+                                "Re-raised window {} (pid {}) after AXFrontmost",
+                                window_id,
+                                pid
+                            ),
+                            Err(e) => tracing::warn!(
+                                "Failed to re-raise window {} after AXFrontmost: {}",
+                                window_id,
+                                e
+                            ),
+                        }
                     } else {
                         // Already frontmost: AXFrontmost is a no-op when the app is already
                         // frontmost, so it won't change the key window (Firefox ignores


### PR DESCRIPTION
Some apps (e.g., Firefox) restore their last-focused window as key when AXFrontmost makes the app come to the front, ignoring the set_main/raise that focus_window issued just before. As a result, when the cursor hovers a Firefox window on a secondary display while a different app is frontmost on the main display, auto-raise (and other focus paths through focus_window) fail to switch focus to the target — Firefox brings its last-focused window (on the main display) to key instead.

Re-issue set_main + raise after set_frontmost in the !is_frontmost branch. For apps that already respected the initial set_main/raise this is a no-op; for Firefox it overrides its last-focused restoration without using activate_application (which would reintroduce the cross-display redirect bug fixed in #129).

The is_frontmost branch (#155) is unchanged.

ref: #129