### PR TITLE
feat!: add --cycle option to exec-or-focus

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,8 @@ yashiki list-outputs             # List all displays
 yashiki get-state                # Get current state
 yashiki exec "open -a Safari"    # Execute command
 yashiki exec --track "borders"   # Execute and terminate on yashiki quit
-yashiki exec-or-focus --app-name Safari "open -a Safari"  # Focus or launch
+yashiki exec-or-focus --app-name Safari "open -a Safari"           # Focus or launch
+yashiki exec-or-focus --app-name Safari --cycle "open -a Safari"   # Cycle through windows of the app
 ```
 
 The `--track` option is useful for launching companion tools like [JankyBorders](https://github.com/FelixKratz/JankyBorders) that should run alongside yashiki:

--- a/completions/zsh/_yashiki
+++ b/completions/zsh/_yashiki
@@ -269,6 +269,7 @@ _yashiki() {
                 exec-or-focus)
                     _arguments \
                         '--app-name[Application name to focus]:app name:' \
+                        '--cycle[Cycle to next window of the app if one is already focused]' \
                         '1:shell command:'
                     ;;
                 set-exec-path)

--- a/yashiki-ipc/src/command.rs
+++ b/yashiki-ipc/src/command.rs
@@ -694,6 +694,8 @@ pub enum Command {
     ExecOrFocus {
         app_name: String,
         command: String,
+        #[serde(default)]
+        cycle: bool,
     },
 
     // Exec path

--- a/yashiki/src/app.rs
+++ b/yashiki/src/app.rs
@@ -1564,6 +1564,7 @@ mod tests {
             &Command::ExecOrFocus {
                 app_name: "Safari".to_string(),
                 command: "open -a Safari".to_string(),
+                cycle: false,
             },
         );
 
@@ -1595,6 +1596,7 @@ mod tests {
             &Command::ExecOrFocus {
                 app_name: "Slack".to_string(), // App not in our mock windows
                 command: "open -a Slack".to_string(),
+                cycle: false,
             },
         );
 
@@ -1608,6 +1610,108 @@ mod tests {
             }
             _ => panic!("Expected ExecCommand effect, got {:?}", result.effects[0]),
         }
+    }
+
+    fn setup_state_with_multiple_ghostty(focused: Option<u32>) -> (State, HotkeyManager) {
+        let ws = MockWindowSystem::new()
+            .with_displays(vec![create_test_display(1, 0.0, 0.0, 1920.0, 1080.0)])
+            .with_windows(vec![
+                create_test_window(1005, 1337, "Ghostty", 0.0, 0.0, 960.0, 1080.0),
+                create_test_window(32, 1337, "Ghostty", 960.0, 0.0, 960.0, 1080.0),
+                create_test_window(500, 2000, "Ghostty", 0.0, 0.0, 480.0, 540.0),
+                create_test_window(200, 3000, "Safari", 0.0, 540.0, 480.0, 540.0),
+            ])
+            .with_focused(focused);
+
+        let mut state = State::new();
+        state.sync_all(&ws);
+
+        let (tx, _rx) = std_mpsc::channel();
+        let dummy_source = Arc::new(AtomicPtr::new(std::ptr::null_mut()));
+        let hotkey_manager = HotkeyManager::new(tx, dummy_source);
+
+        (state, hotkey_manager)
+    }
+
+    fn focused_window_id(result: &crate::effect::CommandResult) -> u32 {
+        match result.effects.first() {
+            Some(Effect::FocusWindow { window_id, .. }) => *window_id,
+            other => panic!("Expected FocusWindow effect, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_exec_or_focus_picks_lowest_window_id() {
+        // Regression test: multiple windows of the same app must deterministically
+        // focus the one with the smallest window_id (not whatever HashMap yields first).
+        let (mut state, mut hotkey_manager) = setup_state_with_multiple_ghostty(Some(200));
+
+        let result = process_command(
+            &mut state,
+            &mut hotkey_manager,
+            &Command::ExecOrFocus {
+                app_name: "Ghostty".to_string(),
+                command: "open -a Ghostty".to_string(),
+                cycle: false,
+            },
+        );
+
+        assert!(matches!(result.response, Response::Ok));
+        assert_eq!(focused_window_id(&result), 32);
+    }
+
+    #[test]
+    fn test_exec_or_focus_cycle_advances_to_next() {
+        // 32 is focused -> cycle picks the next id (500).
+        let (mut state, mut hotkey_manager) = setup_state_with_multiple_ghostty(Some(32));
+
+        let result = process_command(
+            &mut state,
+            &mut hotkey_manager,
+            &Command::ExecOrFocus {
+                app_name: "Ghostty".to_string(),
+                command: "open -a Ghostty".to_string(),
+                cycle: true,
+            },
+        );
+
+        assert_eq!(focused_window_id(&result), 500);
+    }
+
+    #[test]
+    fn test_exec_or_focus_cycle_wraps_around() {
+        // 1005 is the largest matching id -> cycle wraps to the smallest (32).
+        let (mut state, mut hotkey_manager) = setup_state_with_multiple_ghostty(Some(1005));
+
+        let result = process_command(
+            &mut state,
+            &mut hotkey_manager,
+            &Command::ExecOrFocus {
+                app_name: "Ghostty".to_string(),
+                command: "open -a Ghostty".to_string(),
+                cycle: true,
+            },
+        );
+
+        assert_eq!(focused_window_id(&result), 32);
+    }
+
+    #[test]
+    fn test_exec_or_focus_cycle_with_no_focused_match() {
+        // Safari is focused (different app) -> cycle starts at the smallest Ghostty id.
+        let (mut state, mut hotkey_manager) = setup_state_with_multiple_ghostty(Some(200));
+
+        let result = process_command(
+            &mut state,
+            &mut hotkey_manager,
+            &Command::ExecOrFocus {
+                app_name: "Ghostty".to_string(),
+                command: "open -a Ghostty".to_string(),
+                cycle: true,
+            },
+        );
+
+        assert_eq!(focused_window_id(&result), 32);
     }
 
     #[test]

--- a/yashiki/src/app.rs
+++ b/yashiki/src/app.rs
@@ -1720,8 +1720,7 @@ mod tests {
 
     #[test]
     fn test_exec_or_focus_switches_tag_on_target_window_display() {
-        // Regression: cycling to a hidden window on a different display must switch
-        // the tag on that target display, not the currently focused one.
+        // Regression: cycling to a hidden window on a different display must switch the tag on that target display, not the currently focused one.
         let ws = MockWindowSystem::new()
             .with_displays(vec![
                 create_test_display(1, 0.0, 0.0, 1920.0, 1080.0),
@@ -1736,11 +1735,9 @@ mod tests {
         let mut state = State::new();
         state.sync_all(&ws);
 
-        // Put the two Ghostty windows on different tags so they live on separate
-        // tags as well as separate displays.
+        // Put the two Ghostty windows on different tags so they live on separate tags as well as separate displays.
         state.windows.get_mut(&1005).unwrap().tags = crate::core::Tag::from_mask(2);
-        // Display 1 keeps tag 1 visible (where 32 lives, visible).
-        // Display 2 also shows tag 1, so 1005 (on tag 2) is hidden there.
+        // Display 1 keeps tag 1 visible (where 32 lives, visible). Display 2 also shows tag 1, so 1005 (on tag 2) is hidden there.
         state.focused = Some(32);
         state.focused_display = 1;
 

--- a/yashiki/src/app.rs
+++ b/yashiki/src/app.rs
@@ -1634,10 +1634,14 @@ mod tests {
     }
 
     fn focused_window_id(result: &crate::effect::CommandResult) -> u32 {
-        match result.effects.first() {
-            Some(Effect::FocusWindow { window_id, .. }) => *window_id,
-            other => panic!("Expected FocusWindow effect, got {:?}", other),
-        }
+        result
+            .effects
+            .iter()
+            .find_map(|e| match e {
+                Effect::FocusWindow { window_id, .. } => Some(*window_id),
+                _ => None,
+            })
+            .unwrap_or_else(|| panic!("No FocusWindow effect found in {:?}", result.effects))
     }
 
     #[test]
@@ -1712,6 +1716,60 @@ mod tests {
         );
 
         assert_eq!(focused_window_id(&result), 32);
+    }
+
+    #[test]
+    fn test_exec_or_focus_switches_tag_on_target_window_display() {
+        // Regression: cycling to a hidden window on a different display must switch
+        // the tag on that target display, not the currently focused one.
+        let ws = MockWindowSystem::new()
+            .with_displays(vec![
+                create_test_display(1, 0.0, 0.0, 1920.0, 1080.0),
+                create_test_display(2, 1920.0, 0.0, 1920.0, 1080.0),
+            ])
+            .with_windows(vec![
+                create_test_window(32, 1337, "Ghostty", 0.0, 0.0, 960.0, 1080.0),
+                create_test_window(1005, 1337, "Ghostty", 1920.0, 0.0, 960.0, 1080.0),
+            ])
+            .with_focused(Some(32));
+
+        let mut state = State::new();
+        state.sync_all(&ws);
+
+        // Put the two Ghostty windows on different tags so they live on separate
+        // tags as well as separate displays.
+        state.windows.get_mut(&1005).unwrap().tags = crate::core::Tag::from_mask(2);
+        // Display 1 keeps tag 1 visible (where 32 lives, visible).
+        // Display 2 also shows tag 1, so 1005 (on tag 2) is hidden there.
+        state.focused = Some(32);
+        state.focused_display = 1;
+
+        let (tx, _rx) = std_mpsc::channel();
+        let dummy_source = Arc::new(AtomicPtr::new(std::ptr::null_mut()));
+        let mut hotkey_manager = HotkeyManager::new(tx, dummy_source);
+
+        let display1_tags_before = state.displays.get(&1).unwrap().visible_tags.mask();
+
+        let result = process_command(
+            &mut state,
+            &mut hotkey_manager,
+            &Command::ExecOrFocus {
+                app_name: "Ghostty".to_string(),
+                command: "open -a Ghostty".to_string(),
+                cycle: true,
+            },
+        );
+
+        assert!(matches!(result.response, Response::Ok));
+        assert_eq!(focused_window_id(&result), 1005);
+
+        // Display 2 (where 1005 lives) must now show tag 2.
+        assert_eq!(state.displays.get(&2).unwrap().visible_tags.mask(), 2);
+        // Display 1 (the originally focused one) must not be modified.
+        assert_eq!(
+            state.displays.get(&1).unwrap().visible_tags.mask(),
+            display1_tags_before
+        );
     }
 
     #[test]

--- a/yashiki/src/app/command.rs
+++ b/yashiki/src/app/command.rs
@@ -474,9 +474,7 @@ pub fn process_command(
                         is_output_change: false,
                     }])
                 } else {
-                    // Window is hidden, switch to its tag first on the window's own
-                    // display (not the focused one — the target window may live on a
-                    // different display).
+                    // Window is hidden — switch tag on the window's own display, not the focused one (they may differ).
                     if let Some(tag) = window_tags.first_tag() {
                         tracing::info!(
                             "Switching to tag {} on display {} and focusing window for app '{}' (window_id={}, pid={})",

--- a/yashiki/src/app/command.rs
+++ b/yashiki/src/app/command.rs
@@ -1,6 +1,6 @@
 use std::cell::RefCell;
 
-use crate::core::{FocusOutputResult, State};
+use crate::core::{FocusOutputResult, State, Window};
 use crate::effect::{CommandResult, Effect};
 use crate::macos::HotkeyManager;
 use crate::platform::WindowSystem;
@@ -424,13 +424,32 @@ pub fn process_command(
                 }])
             }
         }
-        Command::ExecOrFocus { app_name, command } => {
-            // Check if a window with the given app_name exists
-            let existing_window = state
+        Command::ExecOrFocus {
+            app_name,
+            command,
+            cycle,
+        } => {
+            // Collect matching windows sorted by window id (ascending) so selection
+            // is deterministic regardless of HashMap iteration order.
+            let mut candidates: Vec<&Window> = state
                 .windows
                 .values()
-                .find(|w| w.app_name == *app_name)
-                .map(|w| (w.id, w.pid, w.tags, w.display_id, w.is_hidden()));
+                .filter(|w| w.app_name == *app_name)
+                .collect();
+            candidates.sort_by_key(|w| w.id);
+
+            let target_window = if *cycle {
+                state
+                    .focused
+                    .and_then(|fid| candidates.iter().position(|w| w.id == fid))
+                    .map(|idx| candidates[(idx + 1) % candidates.len()])
+                    .or_else(|| candidates.first().copied())
+            } else {
+                candidates.first().copied()
+            };
+
+            let existing_window =
+                target_window.map(|w| (w.id, w.pid, w.tags, w.display_id, w.is_hidden()));
 
             if let Some((window_id, pid, window_tags, window_display_id, is_hidden)) =
                 existing_window

--- a/yashiki/src/app/command.rs
+++ b/yashiki/src/app/command.rs
@@ -474,16 +474,19 @@ pub fn process_command(
                         is_output_change: false,
                     }])
                 } else {
-                    // Window is hidden, switch to its tag first
+                    // Window is hidden, switch to its tag first on the window's own
+                    // display (not the focused one — the target window may live on a
+                    // different display).
                     if let Some(tag) = window_tags.first_tag() {
                         tracing::info!(
-                            "Switching to tag {} and focusing window for app '{}' (window_id={}, pid={})",
+                            "Switching to tag {} on display {} and focusing window for app '{}' (window_id={}, pid={})",
                             tag,
+                            window_display_id,
                             app_name,
                             window_id,
                             pid
                         );
-                        let moves = state.view_tags(1 << (tag - 1));
+                        let moves = state.view_tags_on_display(1 << (tag - 1), window_display_id);
                         CommandResult::ok_with_effects(vec![
                             Effect::ApplyWindowMoves(moves),
                             Effect::Retile,

--- a/yashiki/src/main.rs
+++ b/yashiki/src/main.rs
@@ -358,6 +358,9 @@ struct ExecOrFocusCmd {
     /// application name to focus
     #[argh(option)]
     app_name: String,
+    /// cycle to the next window of the app if one is already focused
+    #[argh(switch)]
+    cycle: bool,
     /// shell command to execute if app is not running
     #[argh(positional)]
     command: String,
@@ -912,6 +915,7 @@ fn to_command(subcmd: SubCommand) -> Result<Command> {
         SubCommand::ExecOrFocus(cmd) => Ok(Command::ExecOrFocus {
             app_name: cmd.app_name,
             command: cmd.command,
+            cycle: cmd.cycle,
         }),
         SubCommand::ExecPath(_) => Ok(Command::GetExecPath),
         SubCommand::SetExecPath(cmd) => Ok(Command::SetExecPath { path: cmd.path }),
@@ -1206,6 +1210,7 @@ fn parse_command(args: &[String]) -> Result<Command> {
             Ok(Command::ExecOrFocus {
                 app_name: cmd.app_name,
                 command: cmd.command,
+                cycle: cmd.cycle,
             })
         }
         "exec-path" => Ok(Command::GetExecPath),


### PR DESCRIPTION
Add an opt-in `--cycle` flag to `exec-or-focus` so repeated invocations cycle through windows of the same app (sorted by window id, wraps at the end). Useful for hotkeys like `cmd-leftbracket exec-or-focus --app-name Ghostty --cycle …` to walk through multiple terminal windows with the same key, similar to macOS `Cmd+`` `.

Along the way, fix a latent bug in window selection: the previous implementation used `HashMap::values().find()`, so when multiple windows of the same app existed the focused one was non-deterministic. Selection is now sorted by window id (smallest first), making both the default behavior and `--cycle` deterministic.

- `feat: --cycle` (new flag, default off so existing behavior is stable)
- `fix: lowest-id selection` (regression-tested)
- `docs(completions): add --cycle to zsh completion`