### PR TITLE
feat!: add native menu bar workspace indicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,17 @@ yashiki set-auto-raise enabled --delay 100  # Wait 100ms before focusing (useful
 yashiki get-auto-raise                    # Get current mode and delay
 ```
 
+### Menu Bar Tag Indicator
+
+A native macOS menu bar indicator showing each display's visible tags (e.g. `1 | 2`, focused display
+highlighted). Disable it if you use an external status bar instead.
+
+```sh
+yashiki set-menu-bar-status enabled       # Show the indicator (default)
+yashiki set-menu-bar-status disabled      # Hide it (no status item created)
+yashiki get-menu-bar-status               # Get current status
+```
+
 ### Outer Gap
 
 Control the gap between windows and screen edges. Applied globally to all layouts and fullscreen windows.

--- a/completions/zsh/_yashiki
+++ b/completions/zsh/_yashiki
@@ -40,6 +40,14 @@ _yashiki_auto_raise_modes() {
     _describe -t modes 'mode' modes
 }
 
+_yashiki_menu_bar_modes() {
+    local modes=(
+        'enabled:Show the native menu bar tag indicator'
+        'disabled:Hide the native menu bar tag indicator'
+    )
+    _describe -t modes 'mode' modes
+}
+
 _yashiki_layouts() {
     local layouts=(
         'tatami:Master-stack layout'
@@ -138,6 +146,8 @@ _yashiki_subcommands() {
         'get-cursor-warp:Get current cursor warp mode'
         'set-auto-raise:Set auto-raise mode (focus follows mouse)'
         'get-auto-raise:Get current auto-raise mode'
+        'set-menu-bar-status:Set menu bar tag indicator status'
+        'get-menu-bar-status:Get current menu bar tag indicator status'
         'set-outer-gap:Set outer gap'
         'get-outer-gap:Get current outer gap'
         'subscribe:Subscribe to state change events'
@@ -198,7 +208,7 @@ _yashiki() {
     case $state in
         args)
             case $line[1] in
-                start|version|tag-view-last|window-toggle-fullscreen|window-toggle-float|window-close|list-outputs|get-state|focused-window|exec-path|list-rules|get-cursor-warp|get-auto-raise|get-outer-gap|get-mode|quit)
+                start|version|tag-view-last|window-toggle-fullscreen|window-toggle-float|window-close|list-outputs|get-state|focused-window|exec-path|list-rules|get-cursor-warp|get-auto-raise|get-menu-bar-status|get-outer-gap|get-mode|quit)
                     # No arguments
                     ;;
                 declare-mode|enter-mode)
@@ -290,6 +300,9 @@ _yashiki() {
                     _arguments \
                         '--delay[Delay in milliseconds before raising]:delay (ms):' \
                         '1:mode:_yashiki_auto_raise_modes'
+                    ;;
+                set-menu-bar-status)
+                    _arguments '1:mode:_yashiki_menu_bar_modes'
                     ;;
                 set-outer-gap)
                     _arguments '*:gap value:'

--- a/yashiki-ipc/src/command.rs
+++ b/yashiki-ipc/src/command.rs
@@ -25,6 +25,15 @@ pub enum AutoRaiseMode {
     Enabled,
 }
 
+/// Menu bar status - controls the native menu bar tag indicator
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum MenuBarMode {
+    #[default]
+    Enabled,
+    Disabled,
+}
+
 /// Window status - indicates whether a window is managed or ignored
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -732,6 +741,12 @@ pub enum Command {
     },
     GetAutoRaise,
 
+    // Menu bar tag indicator
+    SetMenuBarStatus {
+        mode: MenuBarMode,
+    },
+    GetMenuBarStatus,
+
     // Outer gap
     SetOuterGap {
         values: Vec<String>,
@@ -789,6 +804,7 @@ pub enum Response {
     CursorWarp { mode: CursorWarpMode },
     Mode { name: String },
     AutoRaise { mode: AutoRaiseMode, delay_ms: u64 },
+    MenuBarStatus { mode: MenuBarMode },
     OuterGap { outer_gap: OuterGap },
     LogLevel { level: String, file_mode: bool },
 }

--- a/yashiki-ipc/src/lib.rs
+++ b/yashiki-ipc/src/lib.rs
@@ -5,9 +5,9 @@ pub mod outer_gap;
 
 pub use command::{
     AutoRaiseMode, BindingInfo, ButtonInfo, ButtonState, Command, CursorWarpMode, Direction,
-    ExtendedWindowAttributes, GlobPattern, OutputDirection, OutputInfo, OutputSpecifier, Response,
-    RuleAction, RuleInfo, RuleMatcher, StateInfo, WindowInfo, WindowLevel, WindowLevelName,
-    WindowLevelOther, WindowRule, WindowStatus,
+    ExtendedWindowAttributes, GlobPattern, MenuBarMode, OutputDirection, OutputInfo,
+    OutputSpecifier, Response, RuleAction, RuleInfo, RuleMatcher, StateInfo, WindowInfo,
+    WindowLevel, WindowLevelName, WindowLevelOther, WindowRule, WindowStatus,
 };
 pub use event::{EventFilter, StateEvent, SubscribeRequest};
 pub use layout::{LayoutMessage, LayoutResult, WindowGeometry};

--- a/yashiki/Cargo.toml
+++ b/yashiki/Cargo.toml
@@ -24,5 +24,5 @@ core-foundation-sys.workspace = true
 core-graphics.workspace = true
 objc2 = "0.6"
 objc2-foundation = { version = "0.3", features = ["NSNotification", "NSString", "NSDictionary", "NSRunLoop"] }
-objc2-app-kit = { version = "0.3", features = ["NSWorkspace", "NSRunningApplication", "NSScreen", "NSApplication", "NSEvent"] }
+objc2-app-kit = { version = "0.3", features = ["NSWorkspace", "NSRunningApplication", "NSScreen", "NSApplication", "NSEvent", "NSStatusBar", "NSStatusItem", "NSStatusBarButton", "NSButton", "NSControl", "NSResponder", "NSView", "NSMenu", "NSMenuItem", "objc2-core-foundation"] }
 nix = { version = "0.30", features = ["signal"] }

--- a/yashiki/Cargo.toml
+++ b/yashiki/Cargo.toml
@@ -24,5 +24,5 @@ core-foundation-sys.workspace = true
 core-graphics.workspace = true
 objc2 = "0.6"
 objc2-foundation = { version = "0.3", features = ["NSNotification", "NSString", "NSDictionary", "NSRunLoop"] }
-objc2-app-kit = { version = "0.3", features = ["NSWorkspace", "NSRunningApplication", "NSScreen", "NSApplication", "NSEvent", "NSStatusBar", "NSStatusItem", "NSStatusBarButton", "NSButton", "NSControl", "NSResponder", "NSView", "NSMenu", "NSMenuItem", "objc2-core-foundation"] }
+objc2-app-kit = { version = "0.3", features = ["NSWorkspace", "NSRunningApplication", "NSScreen", "NSApplication", "NSEvent", "NSStatusBar", "NSStatusItem", "NSStatusBarButton", "NSButton", "NSControl", "NSResponder", "NSView", "NSMenu", "NSMenuItem", "NSColor", "NSFont", "NSAttributedString", "objc2-core-foundation"] }
 nix = { version = "0.30", features = ["signal"] }

--- a/yashiki/src/app.rs
+++ b/yashiki/src/app.rs
@@ -12,8 +12,12 @@ use core_foundation_sys::runloop::{
     CFRunLoopAddSource, CFRunLoopGetMain, CFRunLoopSourceContext, CFRunLoopSourceCreate,
 };
 use objc2::rc::Retained;
-use objc2_app_kit::{NSApplication, NSApplicationActivationPolicy, NSEvent, NSEventType};
-use objc2_foundation::MainThreadMarker;
+use objc2::{define_class, msg_send, sel, DefinedClass, MainThreadOnly};
+use objc2_app_kit::{
+    NSApplication, NSApplicationActivationPolicy, NSEvent, NSEventType, NSMenu, NSMenuItem,
+    NSStatusBar, NSStatusItem, NSVariableStatusItemLength,
+};
+use objc2_foundation::{MainThreadMarker, NSObject, NSObjectProtocol, NSString};
 use tokio::sync::mpsc;
 
 mod channels;
@@ -33,6 +37,7 @@ use state_events::{capture_event_state, emit_state_change_events};
 use sync_helper::{process_new_windows, sync_and_process_new_windows, sync_focused_and_process};
 
 use crate::core::State;
+use crate::core::Tag;
 use crate::event::Event;
 use crate::event_emitter::{create_snapshot, EventEmitter};
 use crate::layout::LayoutEngineManager;
@@ -44,6 +49,125 @@ use crate::macos::{
 use crate::pid;
 use crate::platform::{MacOSWindowManipulator, MacOSWindowSystem, WindowManipulator};
 use yashiki_ipc::Command;
+
+/// Format visible tag mask into a menu bar label.
+/// Single tag → "1", multi-tag → "1+3", empty → "–".
+fn format_visible_tags(tags: Tag) -> String {
+    let mut label = String::new();
+    for tag in tags.iter_bits() {
+        if !label.is_empty() {
+            label.push('+');
+        }
+        label.push_str(&tag.to_string());
+    }
+    if label.is_empty() {
+        label.push('\u{2013}');
+    }
+    label
+}
+
+/// Return the visible tags of the focused display, or zero mask if absent.
+fn active_menu_bar_tags(state: &State) -> Tag {
+    state
+        .displays
+        .get(&state.focused_display)
+        .map(|d| d.visible_tags)
+        .unwrap_or(Tag::from_mask(0))
+}
+
+
+// Target object for the status item menu's Quit action.
+// Must be retained because NSMenuItem.target is weak.
+define_class!(
+    #[unsafe(super(NSObject))]
+    #[ivars = Cell<*const RunLoopContext>]
+    struct StatusMenuTarget;
+
+    unsafe impl NSObjectProtocol for StatusMenuTarget {}
+
+    impl StatusMenuTarget {
+        #[unsafe(method(quit:))]
+        fn quit(&self, _sender: &NSMenuItem) {
+            let ctx = self.ivars().get();
+            if ctx.is_null() {
+                tracing::error!("Status menu Quit invoked before run loop context was initialized");
+                return;
+            }
+            unsafe { (&*ctx).quit() };
+        }
+    }
+);
+
+struct MenuBarTagItem {
+    item: Retained<NSStatusItem>,
+    _target: Retained<StatusMenuTarget>,
+    last_title: RefCell<String>,
+}
+
+impl MenuBarTagItem {
+    fn new(mtm: MainThreadMarker, state: &State) -> Self {
+        let status_bar = NSStatusBar::systemStatusBar();
+        let item = status_bar.statusItemWithLength(NSVariableStatusItemLength);
+        item.setVisible(true);
+
+        let title = format_visible_tags(active_menu_bar_tags(state));
+        if let Some(button) = item.button(mtm) {
+            button.setTitle(&NSString::from_str(&title));
+        }
+
+        // Build minimal menu: name, version, separator, Quit.
+        let menu = NSMenu::initWithTitle(NSMenu::alloc(mtm), &NSString::from_str("Yashiki"));
+        menu.setAutoenablesItems(false);
+
+        menu.addItem(&NSMenuItem::sectionHeaderWithTitle(
+            &NSString::from_str("Yashiki"),
+            mtm,
+        ));
+
+        let version = NSMenuItem::new(mtm);
+        version.setTitle(&NSString::from_str(concat!("v", env!("CARGO_PKG_VERSION"))));
+        version.setEnabled(false);
+        menu.addItem(&version);
+
+        menu.addItem(&NSMenuItem::separatorItem(mtm));
+
+        let target: Retained<StatusMenuTarget> = {
+            let this = mtm.alloc::<StatusMenuTarget>();
+            let this = this.set_ivars(Cell::new(std::ptr::null()));
+            unsafe { msg_send![super(this), init] }
+        };
+
+        let quit = NSMenuItem::new(mtm);
+        quit.setTitle(&NSString::from_str("Quit Yashiki"));
+        quit.setKeyEquivalent(&NSString::from_str("q"));
+        unsafe { quit.setAction(Some(sel!(quit:))) };
+        unsafe { quit.setTarget(Some(&target)) };
+        menu.addItem(&quit);
+
+        item.setMenu(Some(&menu));
+
+        Self {
+            item,
+            _target: target,
+            last_title: RefCell::new(title),
+        }
+    }
+
+    fn set_context(&self, ctx: *const RunLoopContext) {
+        self._target.ivars().set(ctx);
+    }
+
+    fn update_from_state(&self, mtm: MainThreadMarker, state: &State) {
+        let title = format_visible_tags(active_menu_bar_tags(state));
+        if title == *self.last_title.borrow() {
+            return;
+        }
+        if let Some(button) = self.item.button(mtm) {
+            button.setTitle(&NSString::from_str(&title));
+        }
+        *self.last_title.borrow_mut() = title;
+    }
+}
 
 pub type LogLevelSetter = Box<dyn Fn(&str) -> Result<(), String>>;
 
@@ -69,6 +193,37 @@ struct RunLoopContext {
     current_log_level: RefCell<String>,
     is_file_logging: bool,
     last_focused_window_destroyed_at: Cell<Option<Instant>>,
+    status_item: MenuBarTagItem,
+}
+
+impl RunLoopContext {
+    fn emit_state_change_events(&self, pre_state: &state_events::PreEventState) {
+        emit_state_change_events(&self.event_emitter, &self.state, pre_state);
+        if let Some(mtm) = MainThreadMarker::new() {
+            self.status_item
+                .update_from_state(mtm, &self.state.borrow());
+        }
+    }
+
+    fn quit(&self) {
+        for process in self.state.borrow().tracked_processes.iter() {
+            self.window_manipulator.terminate_process(process.pid);
+        }
+        self.ns_app.stop(None);
+        if let Some(event) = NSEvent::otherEventWithType_location_modifierFlags_timestamp_windowNumber_context_subtype_data1_data2(
+            NSEventType::ApplicationDefined,
+            objc2_foundation::NSPoint::new(0.0, 0.0),
+            objc2_app_kit::NSEventModifierFlags::empty(),
+            0.0,
+            0,
+            None,
+            0,
+            0,
+            0,
+        ) {
+            self.ns_app.postEvent_atStart(&event, true);
+        }
+    }
 }
 
 pub struct App {}
@@ -200,7 +355,6 @@ impl App {
         if let Err(e) = hotkey_manager.start() {
             tracing::warn!("Failed to start hotkey tap: {}", e);
         }
-
         // Create shared pointer for mouse CFRunLoopSource
         let mouse_source_ptr = Arc::new(AtomicPtr::new(ptr::null_mut()));
         let mouse_source_clone = Arc::clone(&mouse_source_ptr);
@@ -208,6 +362,9 @@ impl App {
         // Create mouse tracker (initially stopped, will be started via IPC)
         let (mouse_event_tx, mouse_event_rx) = std_mpsc::channel::<MousePosition>();
         let mouse_tracker = MouseTracker::new(mouse_event_tx, mouse_source_clone);
+
+        // Create native menu bar tag indicator
+        let status_item = MenuBarTagItem::new(mtm, &state.borrow());
 
         // Create shared context for IPC/hotkey/display sources
         let context = Box::new(RunLoopContext {
@@ -232,8 +389,12 @@ impl App {
             current_log_level: RefCell::new(initial_log_level),
             is_file_logging,
             last_focused_window_destroyed_at: Cell::new(None),
+            status_item,
         });
-        let context_ptr = Box::into_raw(context) as *mut std::ffi::c_void;
+
+        let context_raw = Box::into_raw(context);
+        unsafe { (*context_raw).status_item.set_context(context_raw) };
+        let context_ptr = context_raw as *mut std::ffi::c_void;
 
         // Create CFRunLoopSource for IPC commands (immediate processing)
         extern "C" fn ipc_source_callback(info: *const std::ffi::c_void) {
@@ -293,27 +454,13 @@ impl App {
 
                 // Handle Quit command after sending response
                 if matches!(cmd, Command::Quit) {
-                    // Terminate all tracked processes
-                    for process in ctx.state.borrow().tracked_processes.iter() {
-                        ctx.window_manipulator.terminate_process(process.pid);
-                    }
-                    // Stop NSApplication and post a dummy event to exit run() immediately
-                    ctx.ns_app.stop(None);
-                    // Post dummy event to wake up NSApp.run()
-                    if let Some(event) = NSEvent::otherEventWithType_location_modifierFlags_timestamp_windowNumber_context_subtype_data1_data2(
-                        NSEventType::ApplicationDefined,
-                        objc2_foundation::NSPoint::new(0.0, 0.0),
-                        objc2_app_kit::NSEventModifierFlags::empty(),
-                        0.0,
-                        0,
-                        None,
-                        0,
-                        0,
-                        0,
-                    ) {
-                        ctx.ns_app.postEvent_atStart(&event, true);
-                    }
+                    ctx.quit();
                 }
+            }
+
+            // Refresh menu bar tag indicator after commands may have changed state
+            if let Some(mtm) = MainThreadMarker::new() {
+                ctx.status_item.update_from_state(mtm, &ctx.state.borrow());
             }
 
             // Apply pending hotkey binding changes
@@ -392,6 +539,11 @@ impl App {
                     &ctx.event_emitter,
                     &ctx.observer_manager,
                 );
+            }
+
+            // Refresh menu bar tag indicator after hotkey commands
+            if let Some(mtm) = MainThreadMarker::new() {
+                ctx.status_item.update_from_state(mtm, &ctx.state.borrow());
             }
         }
 
@@ -496,11 +648,7 @@ impl App {
                                         );
                                         ctx.window_manipulator.focus_window(window_id, pid);
                                         ctx.state.borrow_mut().set_focused(Some(window_id));
-                                        emit_state_change_events(
-                                            &ctx.event_emitter,
-                                            &ctx.state,
-                                            &pre_state,
-                                        );
+                                        ctx.emit_state_change_events(&pre_state);
                                         // Clear hover state after focusing
                                         ctx.state.borrow_mut().auto_raise_state.hover_start = None;
                                     } else {
@@ -514,11 +662,7 @@ impl App {
                                             drop(state);
                                             let pre_state = capture_event_state(&ctx.state);
                                             ctx.state.borrow_mut().focused_display = display_id;
-                                            emit_state_change_events(
-                                                &ctx.event_emitter,
-                                                &ctx.state,
-                                                &pre_state,
-                                            );
+                                            ctx.emit_state_change_events(&pre_state);
                                             ctx.state.borrow_mut().auto_raise_state.hover_start =
                                                 None;
                                         }
@@ -564,11 +708,7 @@ impl App {
                                                 pos.x,
                                                 pos.y
                                             );
-                                            emit_state_change_events(
-                                                &ctx.event_emitter,
-                                                &ctx.state,
-                                                &pre_state,
-                                            );
+                                            ctx.emit_state_change_events(&pre_state);
                                             let mut state = ctx.state.borrow_mut();
                                             state.auto_raise_state.display_hover_start = None;
                                         }
@@ -697,7 +837,7 @@ impl App {
                 }
 
                 // Emit state change events (DisplayFocused, WindowUpdated, WindowDestroyed, TagsChanged, etc.)
-                emit_state_change_events(&ctx.event_emitter, &ctx.state, &pre_state);
+                ctx.emit_state_change_events(&pre_state);
             }
         }
 
@@ -812,7 +952,7 @@ impl App {
                             );
                         }
 
-                        emit_state_change_events(&ctx.event_emitter, &ctx.state, &pre_state);
+                        ctx.emit_state_change_events(&pre_state);
                     }
                     WorkspaceEvent::AppTerminated { pid } => {
                         let pre_state = capture_event_state(&ctx.state);
@@ -837,7 +977,7 @@ impl App {
                             );
                         }
 
-                        emit_state_change_events(&ctx.event_emitter, &ctx.state, &pre_state);
+                        ctx.emit_state_change_events(&pre_state);
                     }
                     WorkspaceEvent::AppActivated { pid } => {
                         // Only sync if we don't have an observer OR we don't have windows
@@ -888,7 +1028,7 @@ impl App {
                                 );
                             }
 
-                            emit_state_change_events(&ctx.event_emitter, &ctx.state, &pre_state);
+                            ctx.emit_state_change_events(&pre_state);
                         } else {
                             tracing::debug!("App activated (already tracked), pid {}", pid);
                         }
@@ -1047,7 +1187,7 @@ impl App {
                             }
                             // Emit events for any state changes (e.g., windows added/removed
                             // by handle_event) before skipping further focus handling
-                            emit_state_change_events(&ctx.event_emitter, &ctx.state, &pre_state);
+                            ctx.emit_state_change_events(&pre_state);
                             continue;
                         }
 
@@ -1088,7 +1228,7 @@ impl App {
                                     state.focused_display = intended_display;
                                 }
                             }
-                            emit_state_change_events(&ctx.event_emitter, &ctx.state, &pre_state);
+                            ctx.emit_state_change_events(&pre_state);
                             continue;
                         }
                     }
@@ -1124,7 +1264,7 @@ impl App {
                         .set(Some(Instant::now()));
                 }
 
-                emit_state_change_events(&ctx.event_emitter, &ctx.state, &pre_state);
+                ctx.emit_state_change_events(&pre_state);
 
                 if ctx.event_tx.blocking_send(event).is_err() {
                     tracing::error!("Failed to forward event to tokio");
@@ -1176,7 +1316,7 @@ impl App {
                         }
                     }
                 }
-                emit_state_change_events(&ctx.event_emitter, &ctx.state, &pre_state);
+                ctx.emit_state_change_events(&pre_state);
             } else if focused_window_was_destroyed {
                 // WindowDestroyed arrived first (focused already None):
                 // macOS may have set focus to a hidden window
@@ -1189,7 +1329,7 @@ impl App {
                 }
                 focus_visible_window_if_needed(&ctx.state, &ctx.window_manipulator);
                 needs_retile = true;
-                emit_state_change_events(&ctx.event_emitter, &ctx.state, &pre_state);
+                ctx.emit_state_change_events(&pre_state);
             }
 
             if needs_retile {
@@ -2302,5 +2442,77 @@ mod tests {
         let (cx, cy) = rect.center();
         assert_eq!(cx, 500); // 100 + 800/2
         assert_eq!(cy, 500); // 200 + 600/2
+    }
+
+    // ── Menu bar tag indicator tests ──
+
+    // ── label formatting ──
+
+    #[test]
+    fn menu_bar_tag_format_single() {
+        assert_eq!(format_visible_tags(crate::core::Tag::new(1)), "1");
+        assert_eq!(format_visible_tags(crate::core::Tag::new(9)), "9");
+    }
+
+    #[test]
+    fn menu_bar_tag_format_multi() {
+        let tags = crate::core::Tag::new(1).toggle(crate::core::Tag::new(3));
+        assert_eq!(format_visible_tags(tags), "1+3");
+    }
+
+    #[test]
+    fn menu_bar_tag_format_empty() {
+        assert_eq!(
+            format_visible_tags(crate::core::Tag::from_mask(0)),
+            "\u{2013}"
+        );
+    }
+
+    // ── focused-display selection ──
+
+    #[test]
+    fn menu_bar_tag_follows_focused_display() {
+        let ws = MockWindowSystem::new()
+            .with_displays(vec![
+                create_test_display(1, 0.0, 0.0, 1920.0, 1080.0),
+                create_test_display(2, 1920.0, 0.0, 1920.0, 1080.0),
+            ])
+            .with_windows(vec![create_test_window(
+                100, 1000, "Safari", 0.0, 0.0, 960.0, 1080.0,
+            )]);
+
+        let mut state = State::new();
+        state.sync_all(&ws);
+        // Both displays start on tag 1 (default). Switch display 2 to tag 3.
+        state.displays.get_mut(&2).unwrap().visible_tags = crate::core::Tag::new(3);
+
+        // focused_display is 1 (sync_all sets it to main display = 1)
+        assert_eq!(format_visible_tags(active_menu_bar_tags(&state)), "1");
+
+        // Switch focus to display 2
+        state.focused_display = 2;
+        assert_eq!(format_visible_tags(active_menu_bar_tags(&state)), "3");
+    }
+
+    #[test]
+    fn menu_bar_tag_ignores_non_focused_display_change() {
+        let ws = MockWindowSystem::new()
+            .with_displays(vec![
+                create_test_display(1, 0.0, 0.0, 1920.0, 1080.0),
+                create_test_display(2, 1920.0, 0.0, 1920.0, 1080.0),
+            ])
+            .with_windows(vec![create_test_window(
+                100, 1000, "Safari", 0.0, 0.0, 960.0, 1080.0,
+            )]);
+
+        let mut state = State::new();
+        state.sync_all(&ws);
+        assert_eq!(state.focused_display, 1);
+
+        // Change display 2's tag while display 1 is focused
+        state.displays.get_mut(&2).unwrap().visible_tags = crate::core::Tag::new(5);
+
+        // Label should still show display 1's tag (not display 2's change)
+        assert_eq!(format_visible_tags(active_menu_bar_tags(&state)), "1");
     }
 }

--- a/yashiki/src/app.rs
+++ b/yashiki/src/app.rs
@@ -14,10 +14,13 @@ use core_foundation_sys::runloop::{
 use objc2::rc::Retained;
 use objc2::{define_class, msg_send, sel, DefinedClass, MainThreadOnly};
 use objc2_app_kit::{
-    NSApplication, NSApplicationActivationPolicy, NSEvent, NSEventType, NSMenu, NSMenuItem,
-    NSStatusBar, NSStatusItem, NSVariableStatusItemLength,
+    NSApplication, NSApplicationActivationPolicy, NSColor, NSEvent, NSEventType, NSFont,
+    NSFontAttributeName, NSForegroundColorAttributeName, NSMenu, NSMenuItem, NSStatusBar,
+    NSStatusItem, NSVariableStatusItemLength,
 };
-use objc2_foundation::{MainThreadMarker, NSObject, NSObjectProtocol, NSString};
+use objc2_foundation::{
+    MainThreadMarker, NSMutableAttributedString, NSObject, NSObjectProtocol, NSRange, NSString,
+};
 use tokio::sync::mpsc;
 
 mod channels;
@@ -36,6 +39,7 @@ use retile::{do_retile, do_retile_display};
 use state_events::{capture_event_state, emit_state_change_events};
 use sync_helper::{process_new_windows, sync_and_process_new_windows, sync_focused_and_process};
 
+use crate::core::Display;
 use crate::core::State;
 use crate::core::Tag;
 use crate::event::Event;
@@ -66,15 +70,76 @@ fn format_visible_tags(tags: Tag) -> String {
     label
 }
 
-/// Return the visible tags of the focused display, or zero mask if absent.
-fn active_menu_bar_tags(state: &State) -> Tag {
-    state
-        .displays
-        .get(&state.focused_display)
-        .map(|d| d.visible_tags)
-        .unwrap_or(Tag::from_mask(0))
+/// One menu bar segment: a single display's visible-tags label and whether it is focused.
+struct MenuBarSegment {
+    label: String,
+    focused: bool,
 }
 
+/// Build a menu bar segment per display, ordered left-to-right by frame.x (top-to-bottom on ties).
+fn menu_bar_segments(state: &State) -> Vec<MenuBarSegment> {
+    let mut displays: Vec<&Display> = state.displays.values().collect();
+    displays.sort_by_key(|d| (d.frame.x, d.frame.y));
+    displays
+        .iter()
+        .map(|d| MenuBarSegment {
+            label: format_visible_tags(d.visible_tags),
+            focused: d.id == state.focused_display,
+        })
+        .collect()
+}
+
+const MENU_BAR_SEPARATOR: &str = " | ";
+
+/// Cache key for the rendered segments; focused ones are bracketed so focus moves invalidate it.
+fn menu_bar_cache_key(segments: &[MenuBarSegment]) -> String {
+    if segments.is_empty() {
+        return String::from("\u{2013}");
+    }
+    segments
+        .iter()
+        .map(|s| {
+            if s.focused {
+                format!("[{}]", s.label)
+            } else {
+                s.label.clone()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("|")
+}
+
+/// Build attributed title: menu bar font throughout, focused in `labelColor`, others dimmed to `secondaryLabelColor`.
+fn build_menu_bar_title(segments: &[MenuBarSegment]) -> Retained<NSMutableAttributedString> {
+    let title = NSMutableAttributedString::new();
+    let font = NSFont::menuBarFontOfSize(0.0);
+    let focused_color = NSColor::labelColor();
+    let dim_color = NSColor::secondaryLabelColor();
+
+    let append = |text: &str, focused: bool| {
+        let piece = NSMutableAttributedString::from_nsstring(&NSString::from_str(text));
+        let range = NSRange::new(0, text.encode_utf16().count());
+        let color: &NSColor = if focused { &focused_color } else { &dim_color };
+        unsafe {
+            piece.addAttribute_value_range(NSFontAttributeName, &font, range);
+            piece.addAttribute_value_range(NSForegroundColorAttributeName, color, range);
+        }
+        title.appendAttributedString(&piece);
+    };
+
+    if segments.is_empty() {
+        append("\u{2013}", true);
+        return title;
+    }
+
+    for (i, segment) in segments.iter().enumerate() {
+        if i > 0 {
+            append(MENU_BAR_SEPARATOR, false);
+        }
+        append(&segment.label, segment.focused);
+    }
+    title
+}
 
 // Target object for the status item menu's Quit action.
 // Must be retained because NSMenuItem.target is weak.
@@ -101,7 +166,7 @@ define_class!(
 struct MenuBarTagItem {
     item: Retained<NSStatusItem>,
     _target: Retained<StatusMenuTarget>,
-    last_title: RefCell<String>,
+    last_key: RefCell<String>,
 }
 
 impl MenuBarTagItem {
@@ -110,9 +175,10 @@ impl MenuBarTagItem {
         let item = status_bar.statusItemWithLength(NSVariableStatusItemLength);
         item.setVisible(true);
 
-        let title = format_visible_tags(active_menu_bar_tags(state));
+        let segments = menu_bar_segments(state);
+        let last_key = menu_bar_cache_key(&segments);
         if let Some(button) = item.button(mtm) {
-            button.setTitle(&NSString::from_str(&title));
+            button.setAttributedTitle(&build_menu_bar_title(&segments));
         }
 
         // Build minimal menu: name, version, separator, Quit.
@@ -149,7 +215,7 @@ impl MenuBarTagItem {
         Self {
             item,
             _target: target,
-            last_title: RefCell::new(title),
+            last_key: RefCell::new(last_key),
         }
     }
 
@@ -158,14 +224,15 @@ impl MenuBarTagItem {
     }
 
     fn update_from_state(&self, mtm: MainThreadMarker, state: &State) {
-        let title = format_visible_tags(active_menu_bar_tags(state));
-        if title == *self.last_title.borrow() {
+        let segments = menu_bar_segments(state);
+        let key = menu_bar_cache_key(&segments);
+        if key == *self.last_key.borrow() {
             return;
         }
         if let Some(button) = self.item.button(mtm) {
-            button.setTitle(&NSString::from_str(&title));
+            button.setAttributedTitle(&build_menu_bar_title(&segments));
         }
-        *self.last_title.borrow_mut() = title;
+        *self.last_key.borrow_mut() = key;
     }
 }
 
@@ -2468,51 +2535,120 @@ mod tests {
         );
     }
 
-    // ── focused-display selection ──
+    // ── multi-display segments ──
 
-    #[test]
-    fn menu_bar_tag_follows_focused_display() {
-        let ws = MockWindowSystem::new()
-            .with_displays(vec![
-                create_test_display(1, 0.0, 0.0, 1920.0, 1080.0),
-                create_test_display(2, 1920.0, 0.0, 1920.0, 1080.0),
-            ])
-            .with_windows(vec![create_test_window(
-                100, 1000, "Safari", 0.0, 0.0, 960.0, 1080.0,
-            )]);
-
-        let mut state = State::new();
-        state.sync_all(&ws);
-        // Both displays start on tag 1 (default). Switch display 2 to tag 3.
-        state.displays.get_mut(&2).unwrap().visible_tags = crate::core::Tag::new(3);
-
-        // focused_display is 1 (sync_all sets it to main display = 1)
-        assert_eq!(format_visible_tags(active_menu_bar_tags(&state)), "1");
-
-        // Switch focus to display 2
-        state.focused_display = 2;
-        assert_eq!(format_visible_tags(active_menu_bar_tags(&state)), "3");
+    fn segment_tuple(s: &MenuBarSegment) -> (&str, bool) {
+        (s.label.as_str(), s.focused)
     }
 
     #[test]
-    fn menu_bar_tag_ignores_non_focused_display_change() {
+    fn menu_bar_segments_single_display() {
         let ws = MockWindowSystem::new()
-            .with_displays(vec![
-                create_test_display(1, 0.0, 0.0, 1920.0, 1080.0),
-                create_test_display(2, 1920.0, 0.0, 1920.0, 1080.0),
-            ])
-            .with_windows(vec![create_test_window(
-                100, 1000, "Safari", 0.0, 0.0, 960.0, 1080.0,
-            )]);
+            .with_displays(vec![create_test_display(1, 0.0, 0.0, 1920.0, 1080.0)]);
 
         let mut state = State::new();
         state.sync_all(&ws);
+
+        let segments = menu_bar_segments(&state);
+        assert_eq!(segments.len(), 1);
+        assert_eq!(segment_tuple(&segments[0]), ("1", true));
+        assert_eq!(menu_bar_cache_key(&segments), "[1]");
+    }
+
+    #[test]
+    fn menu_bar_segments_left_to_right() {
+        let ws = MockWindowSystem::new().with_displays(vec![
+            create_test_display(1, 0.0, 0.0, 1920.0, 1080.0),
+            create_test_display(2, 1920.0, 0.0, 1920.0, 1080.0),
+        ]);
+
+        let mut state = State::new();
+        state.sync_all(&ws);
+        state.displays.get_mut(&2).unwrap().visible_tags = crate::core::Tag::new(2);
+        // focused_display is the main display (1)
         assert_eq!(state.focused_display, 1);
 
-        // Change display 2's tag while display 1 is focused
-        state.displays.get_mut(&2).unwrap().visible_tags = crate::core::Tag::new(5);
+        let segments = menu_bar_segments(&state);
+        assert_eq!(
+            segments.iter().map(segment_tuple).collect::<Vec<_>>(),
+            vec![("1", true), ("2", false)]
+        );
+        assert_eq!(menu_bar_cache_key(&segments), "[1]|2");
+    }
 
-        // Label should still show display 1's tag (not display 2's change)
-        assert_eq!(format_visible_tags(active_menu_bar_tags(&state)), "1");
+    #[test]
+    fn menu_bar_segments_ordered_by_position_not_id() {
+        // Display id 2 is physically on the left (x=0), id 1 on the right.
+        let ws = MockWindowSystem::new().with_displays(vec![
+            create_test_display(2, 0.0, 0.0, 1920.0, 1080.0),
+            create_test_display(1, 1920.0, 0.0, 1920.0, 1080.0),
+        ]);
+
+        let mut state = State::new();
+        state.sync_all(&ws);
+        state.displays.get_mut(&2).unwrap().visible_tags = crate::core::Tag::new(3);
+        state.displays.get_mut(&1).unwrap().visible_tags = crate::core::Tag::new(4);
+
+        // Left (id 2, tag 3) must come before right (id 1, tag 4) regardless of id.
+        let segments = menu_bar_segments(&state);
+        assert_eq!(
+            segments
+                .iter()
+                .map(|s| s.label.as_str())
+                .collect::<Vec<_>>(),
+            vec!["3", "4"]
+        );
+    }
+
+    #[test]
+    fn menu_bar_segments_vertical_tiebreak() {
+        // Same x, stacked vertically: top (y=0) before bottom (y=1080).
+        let ws = MockWindowSystem::new().with_displays(vec![
+            create_test_display(1, 0.0, 1080.0, 1920.0, 1080.0),
+            create_test_display(2, 0.0, 0.0, 1920.0, 1080.0),
+        ]);
+
+        let mut state = State::new();
+        state.sync_all(&ws);
+        state.displays.get_mut(&1).unwrap().visible_tags = crate::core::Tag::new(5);
+        state.displays.get_mut(&2).unwrap().visible_tags = crate::core::Tag::new(6);
+
+        let segments = menu_bar_segments(&state);
+        // id 2 (y=0, top) first, then id 1 (y=1080).
+        assert_eq!(
+            segments
+                .iter()
+                .map(|s| s.label.as_str())
+                .collect::<Vec<_>>(),
+            vec!["6", "5"]
+        );
+    }
+
+    #[test]
+    fn menu_bar_segments_focus_moves() {
+        let ws = MockWindowSystem::new().with_displays(vec![
+            create_test_display(1, 0.0, 0.0, 1920.0, 1080.0),
+            create_test_display(2, 1920.0, 0.0, 1920.0, 1080.0),
+        ]);
+
+        let mut state = State::new();
+        state.sync_all(&ws);
+        state.displays.get_mut(&2).unwrap().visible_tags = crate::core::Tag::new(2);
+
+        state.focused_display = 2;
+        let segments = menu_bar_segments(&state);
+        assert_eq!(
+            segments.iter().map(segment_tuple).collect::<Vec<_>>(),
+            vec![("1", false), ("2", true)]
+        );
+        assert_eq!(menu_bar_cache_key(&segments), "1|[2]");
+    }
+
+    #[test]
+    fn menu_bar_segments_empty() {
+        let state = State::new();
+        let segments = menu_bar_segments(&state);
+        assert!(segments.is_empty());
+        assert_eq!(menu_bar_cache_key(&segments), "\u{2013}");
     }
 }

--- a/yashiki/src/app.rs
+++ b/yashiki/src/app.rs
@@ -52,7 +52,7 @@ use crate::macos::{
 };
 use crate::pid;
 use crate::platform::{MacOSWindowManipulator, MacOSWindowSystem, WindowManipulator};
-use yashiki_ipc::Command;
+use yashiki_ipc::{Command, MenuBarMode};
 
 /// Format visible tag mask into a menu bar label.
 /// Single tag → "1", multi-tag → "1+3", empty → "–".
@@ -223,6 +223,11 @@ impl MenuBarTagItem {
         self._target.ivars().set(ctx);
     }
 
+    /// Remove the status item from the menu bar. Dropping alone does not unregister it.
+    fn remove(&self) {
+        NSStatusBar::systemStatusBar().removeStatusItem(&self.item);
+    }
+
     fn update_from_state(&self, mtm: MainThreadMarker, state: &State) {
         let segments = menu_bar_segments(state);
         let key = menu_bar_cache_key(&segments);
@@ -260,15 +265,49 @@ struct RunLoopContext {
     current_log_level: RefCell<String>,
     is_file_logging: bool,
     last_focused_window_destroyed_at: Cell<Option<Instant>>,
-    status_item: MenuBarTagItem,
+    status_item: RefCell<Option<MenuBarTagItem>>,
 }
 
 impl RunLoopContext {
     fn emit_state_change_events(&self, pre_state: &state_events::PreEventState) {
         emit_state_change_events(&self.event_emitter, &self.state, pre_state);
         if let Some(mtm) = MainThreadMarker::new() {
-            self.status_item
-                .update_from_state(mtm, &self.state.borrow());
+            self.refresh_menu_bar(mtm);
+        }
+    }
+
+    /// Refresh the menu bar indicator content. No-op when disabled (status item absent) — no rendering work.
+    fn refresh_menu_bar(&self, mtm: MainThreadMarker) {
+        if let Some(item) = self.status_item.borrow().as_ref() {
+            item.update_from_state(mtm, &self.state.borrow());
+        }
+    }
+
+    /// Create/remove the status item to match `config.menu_bar`. Deferred until init completes; idempotent.
+    fn sync_menu_bar_presence(&self, mtm: MainThreadMarker) {
+        let (init_done, enabled) = {
+            let s = self.state.borrow();
+            (
+                s.config.init_completed,
+                matches!(s.config.menu_bar, MenuBarMode::Enabled),
+            )
+        };
+        if !init_done {
+            return;
+        }
+        let mut slot = self.status_item.borrow_mut();
+        match (enabled, slot.is_some()) {
+            (true, false) => {
+                let item = MenuBarTagItem::new(mtm, &self.state.borrow());
+                item.set_context(self as *const RunLoopContext);
+                *slot = Some(item);
+            }
+            (false, true) => {
+                if let Some(item) = slot.take() {
+                    item.remove();
+                }
+            }
+            _ => {}
         }
     }
 
@@ -430,8 +469,8 @@ impl App {
         let (mouse_event_tx, mouse_event_rx) = std_mpsc::channel::<MousePosition>();
         let mouse_tracker = MouseTracker::new(mouse_event_tx, mouse_source_clone);
 
-        // Create native menu bar tag indicator
-        let status_item = MenuBarTagItem::new(mtm, &state.borrow());
+        // Created lazily once init completes (see ApplyRules handling); disabled never instantiates it.
+        let status_item = RefCell::new(None);
 
         // Create shared context for IPC/hotkey/display sources
         let context = Box::new(RunLoopContext {
@@ -460,7 +499,6 @@ impl App {
         });
 
         let context_raw = Box::into_raw(context);
-        unsafe { (*context_raw).status_item.set_context(context_raw) };
         let context_ptr = context_raw as *mut std::ffi::c_void;
 
         // Create CFRunLoopSource for IPC commands (immediate processing)
@@ -525,9 +563,10 @@ impl App {
                 }
             }
 
-            // Refresh menu bar tag indicator after commands may have changed state
+            // Sync menu bar indicator presence/content after commands (lazy create on init).
             if let Some(mtm) = MainThreadMarker::new() {
-                ctx.status_item.update_from_state(mtm, &ctx.state.borrow());
+                ctx.sync_menu_bar_presence(mtm);
+                ctx.refresh_menu_bar(mtm);
             }
 
             // Apply pending hotkey binding changes
@@ -608,9 +647,10 @@ impl App {
                 );
             }
 
-            // Refresh menu bar tag indicator after hotkey commands
+            // Sync menu bar indicator presence/content after hotkey commands.
             if let Some(mtm) = MainThreadMarker::new() {
-                ctx.status_item.update_from_state(mtm, &ctx.state.borrow());
+                ctx.sync_menu_bar_presence(mtm);
+                ctx.refresh_menu_bar(mtm);
             }
         }
 

--- a/yashiki/src/app/command.rs
+++ b/yashiki/src/app/command.rs
@@ -606,6 +606,16 @@ pub fn process_command(
             delay_ms: state.config.auto_raise_delay_ms,
         }),
 
+        // Menu bar tag indicator
+        Command::SetMenuBarStatus { mode } => {
+            tracing::info!("Set menu bar status: {:?}", mode);
+            state.config.menu_bar = *mode;
+            CommandResult::ok()
+        }
+        Command::GetMenuBarStatus => CommandResult::with_response(Response::MenuBarStatus {
+            mode: state.config.menu_bar,
+        }),
+
         // Outer gap
         Command::SetOuterGap { values } => match OuterGap::from_args(values) {
             Some(gap) => {

--- a/yashiki/src/core/config.rs
+++ b/yashiki/src/core/config.rs
@@ -1,4 +1,4 @@
-use yashiki_ipc::{AutoRaiseMode, CursorWarpMode, OuterGap};
+use yashiki_ipc::{AutoRaiseMode, CursorWarpMode, MenuBarMode, OuterGap};
 
 /// Application configuration settings.
 /// Grouped separately from window/display state for clarity.
@@ -8,6 +8,7 @@ pub struct Config {
     pub cursor_warp: CursorWarpMode,
     pub auto_raise_mode: AutoRaiseMode,
     pub auto_raise_delay_ms: u64,
+    pub menu_bar: MenuBarMode,
     pub outer_gap: OuterGap,
     pub init_completed: bool,
 }

--- a/yashiki/src/main.rs
+++ b/yashiki/src/main.rs
@@ -20,8 +20,8 @@ use app::LogLevelSetter;
 use ipc::IpcClient;
 use yashiki_ipc::{
     AutoRaiseMode, ButtonInfo, ButtonState, Command, CursorWarpMode, Direction, EventFilter,
-    GlobPattern, OutputDirection, OutputSpecifier, Response, RuleAction, RuleMatcher, WindowLevel,
-    WindowLevelName, WindowLevelOther, WindowRule, WindowStatus,
+    GlobPattern, MenuBarMode, OutputDirection, OutputSpecifier, Response, RuleAction, RuleMatcher,
+    WindowLevel, WindowLevelName, WindowLevelOther, WindowRule, WindowStatus,
 };
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -77,6 +77,8 @@ enum SubCommand {
     GetCursorWarp(GetCursorWarpCmd),
     SetAutoRaise(SetAutoRaiseCmd),
     GetAutoRaise(GetAutoRaiseCmd),
+    SetMenuBarStatus(SetMenuBarStatusCmd),
+    GetMenuBarStatus(GetMenuBarStatusCmd),
     SetOuterGap(SetOuterGapCmd),
     GetOuterGap(GetOuterGapCmd),
     SetLogLevel(SetLogLevelCmd),
@@ -506,6 +508,20 @@ struct SetAutoRaiseCmd {
 #[argh(subcommand, name = "get-auto-raise")]
 struct GetAutoRaiseCmd {}
 
+/// Set menu bar tag indicator status
+#[derive(FromArgs)]
+#[argh(subcommand, name = "set-menu-bar-status")]
+struct SetMenuBarStatusCmd {
+    /// mode: enabled, disabled
+    #[argh(positional)]
+    mode: String,
+}
+
+/// Get current menu bar tag indicator status
+#[derive(FromArgs)]
+#[argh(subcommand, name = "get-menu-bar-status")]
+struct GetMenuBarStatusCmd {}
+
 /// Set the outer gap (gap between windows and screen edges)
 #[derive(FromArgs)]
 #[argh(subcommand, name = "set-outer-gap")]
@@ -821,6 +837,13 @@ fn run_cli(subcmd: SubCommand) -> Result<()> {
                 println!("{}", mode_str);
             }
         }
+        Response::MenuBarStatus { mode } => {
+            let mode_str = match mode {
+                MenuBarMode::Enabled => "enabled",
+                MenuBarMode::Disabled => "disabled",
+            };
+            println!("{}", mode_str);
+        }
         Response::OuterGap { outer_gap } => {
             println!("{}", outer_gap);
         }
@@ -1041,6 +1064,11 @@ fn to_command(subcmd: SubCommand) -> Result<Command> {
             Ok(Command::SetAutoRaise { mode, delay_ms })
         }
         SubCommand::GetAutoRaise(_) => Ok(Command::GetAutoRaise),
+        SubCommand::SetMenuBarStatus(cmd) => {
+            let mode = parse_menu_bar_mode(&cmd.mode)?;
+            Ok(Command::SetMenuBarStatus { mode })
+        }
+        SubCommand::GetMenuBarStatus(_) => Ok(Command::GetMenuBarStatus),
         SubCommand::SetOuterGap(cmd) => {
             if cmd.values.is_empty() {
                 bail!("set-outer-gap requires at least one value");
@@ -1347,6 +1375,12 @@ fn parse_command(args: &[String]) -> Result<Command> {
             Ok(Command::SetAutoRaise { mode, delay_ms })
         }
         "get-auto-raise" => Ok(Command::GetAutoRaise),
+        "set-menu-bar-status" => {
+            let cmd: SetMenuBarStatusCmd = from_argh(cmd_name, &cmd_args)?;
+            let mode = parse_menu_bar_mode(&cmd.mode)?;
+            Ok(Command::SetMenuBarStatus { mode })
+        }
+        "get-menu-bar-status" => Ok(Command::GetMenuBarStatus),
         "set-outer-gap" => {
             let cmd: SetOuterGapCmd = from_argh(cmd_name, &cmd_args)?;
             if cmd.values.is_empty() {
@@ -1411,6 +1445,14 @@ fn parse_auto_raise_mode(s: &str) -> Result<AutoRaiseMode> {
         "disabled" => Ok(AutoRaiseMode::Disabled),
         "enabled" => Ok(AutoRaiseMode::Enabled),
         _ => bail!("Unknown auto-raise mode: {} (use disabled, enabled)", s),
+    }
+}
+
+fn parse_menu_bar_mode(s: &str) -> Result<MenuBarMode> {
+    match s.to_lowercase().as_str() {
+        "enabled" => Ok(MenuBarMode::Enabled),
+        "disabled" => Ok(MenuBarMode::Disabled),
+        _ => bail!("Unknown menu bar status: {} (use enabled, disabled)", s),
     }
 }
 


### PR DESCRIPTION
## Summary

Adds a minimal native macOS menu bar indicator showing the focused display's visible tag(s).

This is intentionally small: it does not replace the existing `yashiki subscribe` workflow for richer external bars, but gives users a built-in native indicator for the basic "what workspace am I on?" case.

Fixes #175.

## Behavior

- Adds an `NSStatusItem` in the macOS menu bar.
- Displays focused display visible tags:
  - `1`
  - `1+3`
  - `–` for empty fallback
- Updates after state-changing paths.
- Adds a minimal native menu:
  - `Yashiki`
  - package version
  - `Quit Yashiki`

## Design

Kept deliberately conservative:

- no new crates
- no external status bar process
- no config surface
- no IPC changes
- no icon/theme/menu customization
- no workspace list or reload/settings actions

Yashiki already runs as an AppKit accessory app and already depends on `objc2-app-kit`, so this uses the existing native stack instead of adding another moving part.

The menu Quit action reuses the same shutdown path as IPC `yashiki quit`, including tracked process cleanup.

## Unsafe/AppKit notes

The patch avoids avoidable unsafe blocks where possible. Remaining unsafe is localized to objc2/AppKit target-action boundaries:

- initializing the `define_class!` target object
- setting `NSMenuItem` target/action
- bridging the AppKit menu target back to the retained run-loop context

Those mirror existing objc2 patterns in the codebase and are required by the current AppKit binding shape.

## Tests

Adds pure tests for tag label behavior:

- single-tag formatting
- multi-tag formatting
- empty fallback
- focused-display selection
- ignoring non-focused display tag changes

## Verification

```sh
nix develop --impure -c cargo test -p yashiki menu_bar_tag
nix develop --impure -c cargo build -p yashiki
```

Both pass locally.
