### PR TITLE
docs: add community layout engines section

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,6 +436,16 @@ AeroSpace-style stacked windows with focused window at front.
 | `set-orientation <h\|v>` | Horizontal or vertical stacking |
 | `toggle-orientation` | Toggle orientation |
 
+## Community Layout Engines
+
+Third-party layout engines built on the external layout protocol:
+
+| Engine | Description |
+|--------|-------------|
+| [kakejiku](https://github.com/pkarpovich/yashiki-layout-kakejiku) | Vertical main + stacked rows, made for portrait monitors |
+
+To add yours, open a pull request.
+
 ## Custom Layout Engines
 
 Yashiki supports external layout engines via stdin/stdout JSON protocol.

--- a/docs/layout-engine.md
+++ b/docs/layout-engine.md
@@ -252,16 +252,6 @@ yashiki set-outer-gap 10
 yashiki layout-cmd --layout tatami set-inner-gap 10
 ```
 
-## Community Layout Engines
-
-Third-party layout engines built on this protocol:
-
-| Name | Description |
-|------|-------------|
-| [kakejiku](https://github.com/pkarpovich/yashiki-layout-kakejiku) | Vertical main + stacked rows layout for portrait monitors |
-
-To add yours to this list, open a pull request.
-
 ## Debugging Tips
 
 1. Test your layout engine standalone:

--- a/docs/layout-engine.md
+++ b/docs/layout-engine.md
@@ -252,6 +252,16 @@ yashiki set-outer-gap 10
 yashiki layout-cmd --layout tatami set-inner-gap 10
 ```
 
+## Community Layout Engines
+
+Third-party layout engines built on this protocol:
+
+| Name | Description |
+|------|-------------|
+| [kakejiku](https://github.com/pkarpovich/yashiki-layout-kakejiku) | Vertical main + stacked rows layout for portrait monitors |
+
+To add yours to this list, open a pull request.
+
 ## Debugging Tips
 
 1. Test your layout engine standalone:


### PR DESCRIPTION
Adds a "Community Layout Engines" section to `docs/layout-engine.md` with [kakejiku](https://github.com/pkarpovich/yashiki-layout-kakejiku) as the first entry, as discussed in #177.

Closes #177