### PR TITLE
fix: re-register incomplete observers on app activation

### DIFF
--- a/yashiki/src/app.rs
+++ b/yashiki/src/app.rs
@@ -1087,6 +1087,26 @@ impl App {
                         ctx.emit_state_change_events(&pre_state);
                     }
                     WorkspaceEvent::AppActivated { pid } => {
+                        // Re-register observers left incomplete by a registration failure at launch
+                        // (e.g. AXFocusedWindowChanged returning -25204 while a heavy app is still
+                        // starting). The app is fully ready by activation time, so this succeeds and
+                        // restores focus-change notifications that FocusIntent depends on.
+                        if ctx.observer_manager.borrow().has_incomplete_observer(pid) {
+                            tracing::info!(
+                                "Re-registering incomplete observer for pid {} on activation",
+                                pid
+                            );
+                            if let Err(e) =
+                                ctx.observer_manager.borrow_mut().reregister_observer(pid)
+                            {
+                                tracing::warn!(
+                                    "Failed to re-register observer for pid {}: {}",
+                                    pid,
+                                    e
+                                );
+                            }
+                        }
+
                         // Only sync if we don't have an observer OR we don't have windows
                         // This avoids redundant work when the app is already being tracked
                         let needs_sync = !ctx.observer_manager.borrow().has_observer(pid)


### PR DESCRIPTION
When an AX observer's notification registration partially fails at app launch (e.g. AXFocusedWindowChanged returning -25204 while a heavy app like Firefox is still starting), the observer was marked incomplete and only retried once, immediately, in the AppLaunched handler. If that retry also failed it stayed incomplete until yashiki restarted, so focus-change notifications never arrived and FocusIntent could not correct macOS redirecting focus to a hidden window of the same app.

Retry incomplete observers on WorkspaceEvent::AppActivated, when the app is fully ready, so the registration succeeds and the observer self-heals without a restart.