### PR TITLE
fix: show menu bar indicator under macOS 26 Tahoe

### DIFF
--- a/Info.plist.template
+++ b/Info.plist.template
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>CFBundleExecutable</key>
-    <string>yashiki-launcher</string>
+    <string>yashiki</string>
     <key>CFBundleIdentifier</key>
     <string>dev.typester.yashiki</string>
     <key>CFBundleName</key>

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -118,19 +118,13 @@ mkdir -p "${APP_DIR}/Contents/MacOS"
 mkdir -p "${APP_DIR}/Contents/Resources/layouts"
 
 # Copy binaries
+# No launcher shim — yashiki is the bundle executable itself (macOS 26 menu bar fix, https://github.com/typester/yashiki/issues/182).
 cp "${BUILD_DIR}/yashiki" "${APP_DIR}/Contents/MacOS/"
 cp "${BUILD_DIR}/yashiki-layout-tatami" "${APP_DIR}/Contents/Resources/layouts/"
 cp "${BUILD_DIR}/yashiki-layout-byobu" "${APP_DIR}/Contents/Resources/layouts/"
 
 # Copy assets
 cp "${PROJECT_ROOT}/resources/icon/Assets.car" "${APP_DIR}/Contents/Resources/"
-
-# Create launcher wrapper
-cat > "${APP_DIR}/Contents/MacOS/yashiki-launcher" << 'EOF'
-#!/bin/bash
-exec "$(dirname "$0")/yashiki" start "$@"
-EOF
-chmod +x "${APP_DIR}/Contents/MacOS/yashiki-launcher"
 
 # Generate Info.plist
 sed "s/VERSION_PLACEHOLDER/${VERSION}/g" "${PROJECT_ROOT}/Info.plist.template" > "${APP_DIR}/Contents/Info.plist"

--- a/yashiki/src/main.rs
+++ b/yashiki/src/main.rs
@@ -621,28 +621,39 @@ fn init_logging() -> (Option<LogLevelSetter>, String, bool) {
     }
 }
 
+/// True when the executable lives inside a `.app` bundle (launched via LaunchServices).
+fn launched_from_app_bundle() -> bool {
+    std::env::current_exe()
+        .map(|p| p.to_string_lossy().contains(".app/Contents/MacOS/"))
+        .unwrap_or(false)
+}
+
+fn start_daemon() -> Result<()> {
+    let (log_level_setter, initial_level, is_file_logging) = init_logging();
+    tracing::info!("yashiki starting");
+    app::App::run(log_level_setter, initial_level, is_file_logging)
+}
+
 fn main() -> Result<()> {
     let cli: Cli = argh::from_env();
 
     match cli.command {
         None => {
-            // No subcommand - show help (simulate --help)
-            let args: Vec<&str> = vec!["yashiki", "--help"];
-            match Cli::from_args(&args[..1], &args[1..]) {
-                Ok(_) => {}
-                Err(e) => {
-                    println!("{}", e.output);
+            // Launched as a .app bundle: run the daemon (macOS 26 menu bar fix, https://github.com/typester/yashiki/issues/182).
+            if launched_from_app_bundle() {
+                start_daemon()
+            } else {
+                let args: Vec<&str> = vec!["yashiki", "--help"];
+                match Cli::from_args(&args[..1], &args[1..]) {
+                    Ok(_) => {}
+                    Err(e) => {
+                        println!("{}", e.output);
+                    }
                 }
+                Ok(())
             }
-            Ok(())
         }
-        Some(SubCommand::Start(_)) => {
-            // Start daemon
-            let (log_level_setter, initial_level, is_file_logging) = init_logging();
-
-            tracing::info!("yashiki starting");
-            app::App::run(log_level_setter, initial_level, is_file_logging)
-        }
+        Some(SubCommand::Start(_)) => start_daemon(),
         Some(SubCommand::Version(_)) => {
             println!("v{}", VERSION);
             Ok(())


### PR DESCRIPTION
fixes #182

On macOS 26 (Tahoe), the native menu bar workspace indicator never appeared when Yashiki was launched as an app bundle — only when started from a terminal.

The bundle used a `yashiki-launcher` shell script as `CFBundleExecutable`, which `exec`s the real `yashiki` binary. The running process image therefore did not match `CFBundleExecutable`, so macOS 26 could not map the process back to its bundle id and refused to give the `NSStatusItem` a menu bar slot — the item was created correctly but parked off-screen. Launching from a terminal works because no bundle-id mapping is involved.

Drop the launcher and make `yashiki` itself the bundle executable. Since LaunchServices starts the executable with no arguments, `yashiki` now starts the daemon when run with no subcommand from inside a `.app` bundle, and still prints help when run with no subcommand from a shell.

This is the same class of bug several menu bar apps hit on Tahoe (process can't be mapped to its bundle id): https://developer.apple.com/forums/thread/794920

Verified by launching the rebuilt bundle via LaunchServices: the status item moves from an off-screen position into a normal menu bar slot and becomes visible on both displays.