### PR TITLE
fix(display): follow screen-parameter changes

### DIFF
--- a/yashiki/src/app.rs
+++ b/yashiki/src/app.rs
@@ -47,7 +47,7 @@ use crate::event_emitter::{create_snapshot, EventEmitter};
 use crate::layout::LayoutEngineManager;
 use crate::macos;
 use crate::macos::{
-    DisplayReconfigEvent, HotkeyManager, MousePosition, MouseTracker, ObserverManager,
+    DisplayChangeSignal, HotkeyManager, MousePosition, MouseTracker, ObserverManager,
     WorkspaceEvent, WorkspaceWatcher,
 };
 use crate::pid;
@@ -250,7 +250,7 @@ struct RunLoopContext {
     observer_event_rx: std_mpsc::Receiver<Event>,
     workspace_event_rx: std_mpsc::Receiver<WorkspaceEvent>,
     snapshot_request_rx: std_mpsc::Receiver<SnapshotRequest>,
-    display_reconfig_rx: std_mpsc::Receiver<DisplayReconfigEvent>,
+    display_reconfig_rx: std_mpsc::Receiver<DisplayChangeSignal>,
     event_tx: mpsc::Sender<Event>,
     event_emitter: EventEmitter,
     observer_manager: RefCell<ObserverManager>,
@@ -876,14 +876,28 @@ impl App {
         extern "C" fn display_source_callback(info: *const std::ffi::c_void) {
             let ctx = unsafe { &*(info as *const RunLoopContext) };
 
-            // Process all pending display reconfig events
-            while let Ok(event) = ctx.display_reconfig_rx.try_recv() {
-                tracing::info!(
-                    "Display reconfiguration: display_id={}, flags={:#x}",
-                    event.display_id,
-                    event.flags
-                );
+            // Both the reconfiguration callback and the screen-parameter notification
+            // arrive here, one signal per affected display in the first case, and the
+            // reconciliation covers the whole configuration either way. Drain the queue
+            // and reconcile once rather than repeating it per signal.
+            let mut pending = 0usize;
+            while let Ok(signal) = ctx.display_reconfig_rx.try_recv() {
+                if let DisplayChangeSignal::Reconfiguration { display_id, flags } = signal {
+                    tracing::info!(
+                        "Display reconfiguration: display_id={}, flags={:#x}",
+                        display_id,
+                        flags
+                    );
+                }
+                pending += 1;
+            }
 
+            if pending > 0 {
+                if pending > 1 {
+                    tracing::debug!("Coalesced {} display change signals", pending);
+                }
+
+                tracing::debug!("Reconciling displays");
                 // Capture state before display change for event emission
                 let pre_state = capture_event_state(&ctx.state);
 
@@ -1159,12 +1173,6 @@ impl App {
                         } else {
                             tracing::debug!("App activated (already tracked), pid {}", pid);
                         }
-                    }
-                    WorkspaceEvent::DisplaysChanged => {
-                        // Handled by display_source_callback via CGDisplayRegisterReconfigurationCallback
-                        tracing::debug!(
-                            "DisplaysChanged event received (handled by display callback)"
-                        );
                     }
                 }
             }

--- a/yashiki/src/app.rs
+++ b/yashiki/src/app.rs
@@ -901,11 +901,16 @@ impl App {
                 // Capture state before display change for event emission
                 let pre_state = capture_event_state(&ctx.state);
 
-                // Handle display change
-                let result = ctx
+                // Handle display change. `None` means the configuration read from the
+                // OS is the one already held: emitting events or retiling here would
+                // move every window and wake every subscriber for nothing.
+                let Some(result) = ctx
                     .state
                     .borrow_mut()
-                    .handle_display_change(&ctx.window_system);
+                    .handle_display_change(&ctx.window_system)
+                else {
+                    return;
+                };
 
                 // Emit display add/remove/update events (not covered by emit_state_change_events)
                 let focused_display = ctx.state.borrow().focused_display;
@@ -939,21 +944,15 @@ impl App {
                     &ctx.event_emitter,
                 );
 
-                // Retile affected displays
-                if !result.displays_to_retile.is_empty() {
-                    for display_id in result.displays_to_retile {
-                        do_retile_display(
-                            &ctx.state,
-                            &ctx.layout_engine_manager,
-                            &ctx.window_manipulator,
-                            display_id,
-                        );
-                    }
-                } else {
-                    do_retile(
+                // Retile the affected displays, and only those. The list is exhaustive:
+                // every branch that returns `Some` fills in the displays whose layout
+                // the change can move, so an empty list means none of them do.
+                for display_id in result.displays_to_retile {
+                    do_retile_display(
                         &ctx.state,
                         &ctx.layout_engine_manager,
                         &ctx.window_manipulator,
+                        display_id,
                     );
                 }
 

--- a/yashiki/src/app/channels.rs
+++ b/yashiki/src/app/channels.rs
@@ -10,7 +10,7 @@ use tokio::sync::mpsc;
 
 use crate::event::Event;
 use crate::ipc::{EventBroadcaster, EventServer, IpcServer};
-use crate::macos::DisplayReconfigEvent;
+use crate::macos::DisplayChangeSignal;
 use yashiki_ipc::{Command, Response, StateEvent};
 
 pub type IpcCommandWithResponse = (Command, mpsc::Sender<Response>);
@@ -50,8 +50,8 @@ pub struct MainChannels {
     pub event_tx: mpsc::Sender<Event>,
     pub state_event_tx: std_mpsc::Sender<StateEvent>,
     pub snapshot_request_rx: std_mpsc::Receiver<SnapshotRequest>,
-    pub display_reconfig_tx: std_mpsc::Sender<DisplayReconfigEvent>,
-    pub display_reconfig_rx: std_mpsc::Receiver<DisplayReconfigEvent>,
+    pub display_reconfig_tx: std_mpsc::Sender<DisplayChangeSignal>,
+    pub display_reconfig_rx: std_mpsc::Receiver<DisplayChangeSignal>,
     pub ipc_source: Arc<AtomicPtr<std::ffi::c_void>>,
 }
 
@@ -81,7 +81,7 @@ pub fn create_channels() -> (TokioChannels, MainChannels) {
         std_mpsc::channel::<SnapshotRequest>();
 
     // Channel: display reconfiguration events (callback -> main thread)
-    let (display_reconfig_tx, display_reconfig_rx) = std_mpsc::channel::<DisplayReconfigEvent>();
+    let (display_reconfig_tx, display_reconfig_rx) = std_mpsc::channel::<DisplayChangeSignal>();
 
     // Note: register_display_callback is called in run_main_loop after source creation
 

--- a/yashiki/src/core/state/display.rs
+++ b/yashiki/src/core/state/display.rs
@@ -1,5 +1,6 @@
 use std::collections::HashSet;
 
+use crate::core::Rect;
 use crate::macos::DisplayId;
 use crate::platform::WindowSystem;
 use yashiki_ipc::OutputDirection;
@@ -20,13 +21,38 @@ use super::sync::sync_all;
 /// The order difference is intentional:
 /// - On reconnect: must sync first to create Display entries, then restore saved state
 /// - On disconnect: must save state before removing displays
-pub fn handle_display_change<W: WindowSystem>(state: &mut State, ws: &W) -> DisplayChangeResult {
+///
+/// Returns `None` when the configuration read from the OS is the one already held,
+/// which the caller must treat as "do nothing at all". An empty `displays_to_retile`
+/// inside `Some` means the same thing for retiling specifically: the displays that
+/// need one, of which there may be none.
+pub fn handle_display_change<W: WindowSystem>(
+    state: &mut State,
+    ws: &W,
+) -> Option<DisplayChangeResult> {
     let display_infos = ws.get_all_displays();
     let current_ids: HashSet<_> = display_infos.iter().map(|d| d.id).collect();
     let previous_ids: HashSet<_> = state.displays.keys().copied().collect();
 
     let removed_ids: Vec<_> = previous_ids.difference(&current_ids).copied().collect();
     let added_ids: HashSet<_> = current_ids.difference(&previous_ids).copied().collect();
+
+    // The OS emits several notifications around one configuration change, and some
+    // of them describe a configuration we already hold. Retiling on those moves
+    // every window for nothing, so compare first and bail out when nothing moved.
+    if removed_ids.is_empty() && added_ids.is_empty() {
+        let unchanged = display_infos.iter().all(|info| {
+            state.displays.get(&info.id).is_some_and(|display| {
+                display.name == info.name
+                    && display.is_main == info.is_main
+                    && display.frame == Rect::from_bounds(&info.frame)
+            })
+        });
+        if unchanged {
+            tracing::debug!("Display configuration unchanged, nothing to do");
+            return None;
+        }
+    }
 
     // === Reconnect branch: no displays removed, possibly some added ===
     if removed_ids.is_empty() {
@@ -88,13 +114,13 @@ pub fn handle_display_change<W: WindowSystem>(state: &mut State, ws: &W) -> Disp
             .cloned()
             .collect();
 
-        return DisplayChangeResult {
+        return Some(DisplayChangeResult {
             window_moves,
             displays_to_retile: displays_to_retile.into_iter().collect(),
             added,
             removed: vec![],
             new_window_ids,
-        };
+        });
     }
 
     // === Disconnect branch: some displays removed ===
@@ -108,13 +134,13 @@ pub fn handle_display_change<W: WindowSystem>(state: &mut State, ws: &W) -> Disp
 
     let Some(fallback_id) = fallback_display else {
         tracing::warn!("No fallback display available");
-        return DisplayChangeResult {
+        return Some(DisplayChangeResult {
             window_moves: vec![],
             displays_to_retile: vec![],
             added: vec![],
             removed: removed_ids,
             new_window_ids: vec![],
-        };
+        });
     };
 
     let mut window_moves = Vec::new();
@@ -173,13 +199,13 @@ pub fn handle_display_change<W: WindowSystem>(state: &mut State, ws: &W) -> Disp
 
     let displays_to_retile: Vec<_> = affected_displays.into_iter().collect();
 
-    DisplayChangeResult {
+    Some(DisplayChangeResult {
         window_moves,
         displays_to_retile,
         added,
         removed: removed_ids,
         new_window_ids,
-    }
+    })
 }
 
 pub fn focus_output(state: &mut State, direction: OutputDirection) -> Option<FocusOutputResult> {

--- a/yashiki/src/core/state/mod.rs
+++ b/yashiki/src/core/state/mod.rs
@@ -605,7 +605,10 @@ impl State {
 
     // Display operations - delegated to state/display.rs
 
-    pub fn handle_display_change<W: WindowSystem>(&mut self, ws: &W) -> DisplayChangeResult {
+    pub fn handle_display_change<W: WindowSystem>(
+        &mut self,
+        ws: &W,
+    ) -> Option<DisplayChangeResult> {
         handle_display_change(self, ws)
     }
 
@@ -1474,12 +1477,66 @@ mod tests {
             )])
             .with_focused(Some(100));
 
-        let result = state.handle_display_change(&ws2);
+        let result = state
+            .handle_display_change(&ws2)
+            .expect("display configuration changed");
 
         assert_eq!(result.added.len(), 1);
         assert_eq!(result.added[0].id, 2);
         assert!(result.removed.is_empty());
         assert_eq!(state.displays.len(), 2);
+    }
+
+    #[test]
+    fn test_handle_display_change_unchanged_configuration_is_a_no_op() {
+        let ws = MockWindowSystem::new()
+            .with_displays(vec![
+                create_test_display(1, 0.0, 0.0, 1920.0, 1080.0),
+                create_test_display(2, 1920.0, 0.0, 1920.0, 1080.0),
+            ])
+            .with_windows(vec![create_test_window(
+                100, 1000, "Safari", 100.0, 100.0, 800.0, 600.0,
+            )])
+            .with_focused(Some(100));
+
+        let mut state = State::new();
+        state.sync_all(&ws);
+
+        // Same configuration read again. `None` rather than an empty result: the
+        // caller retiles exactly the displays it is handed, so an empty list would
+        // still be a result to act on, and the distinction is the whole point.
+        assert!(
+            state.handle_display_change(&ws).is_none(),
+            "an unchanged configuration must report no change at all"
+        );
+        assert_eq!(state.displays.len(), 2);
+    }
+
+    #[test]
+    fn test_handle_display_change_moved_display_still_retiles() {
+        let ws1 = MockWindowSystem::new()
+            .with_displays(vec![create_test_display(1, 0.0, 0.0, 1920.0, 1080.0)])
+            .with_windows(vec![create_test_window(
+                100, 1000, "Safari", 100.0, 100.0, 800.0, 600.0,
+            )])
+            .with_focused(Some(100));
+
+        let mut state = State::new();
+        state.sync_all(&ws1);
+
+        // Same display id, different frame: the menu bar appearing looks like this.
+        let ws2 = MockWindowSystem::new()
+            .with_displays(vec![create_test_display(1, 0.0, 30.0, 1920.0, 1050.0)])
+            .with_windows(vec![create_test_window(
+                100, 1000, "Safari", 100.0, 100.0, 800.0, 600.0,
+            )])
+            .with_focused(Some(100));
+
+        let result = state
+            .handle_display_change(&ws2)
+            .expect("display configuration changed");
+
+        assert!(!result.displays_to_retile.is_empty());
     }
 
     #[test]
@@ -1505,7 +1562,9 @@ mod tests {
             )])
             .with_focused(Some(100));
 
-        let result = state.handle_display_change(&ws2);
+        let result = state
+            .handle_display_change(&ws2)
+            .expect("display configuration changed");
 
         assert!(result.added.is_empty());
         assert_eq!(result.removed.len(), 1);
@@ -1539,7 +1598,9 @@ mod tests {
             ])
             .with_focused(Some(100));
 
-        let result = state.handle_display_change(&ws2);
+        let result = state
+            .handle_display_change(&ws2)
+            .expect("display configuration changed");
 
         assert_eq!(state.windows.get(&101).unwrap().display_id, 1);
 
@@ -2841,7 +2902,9 @@ mod tests {
             ])
             .with_focused(Some(100));
 
-        let _result = state.handle_display_change(&ws2);
+        state
+            .handle_display_change(&ws2)
+            .expect("display configuration changed");
 
         // Window 101 should now be on display 1 (fallback) with orphaned_from = Some(2)
         assert_eq!(state.windows.get(&101).unwrap().display_id, 1);
@@ -2878,7 +2941,9 @@ mod tests {
             ])
             .with_focused(Some(100));
 
-        let _result = state.handle_display_change(&ws2);
+        state
+            .handle_display_change(&ws2)
+            .expect("display configuration changed");
         assert_eq!(state.windows.get(&101).unwrap().display_id, 1);
         assert_eq!(state.windows.get(&101).unwrap().orphaned_from, Some(2));
 
@@ -2894,7 +2959,9 @@ mod tests {
             ])
             .with_focused(Some(100));
 
-        let result = state.handle_display_change(&ws3);
+        let result = state
+            .handle_display_change(&ws3)
+            .expect("display configuration changed");
 
         // Window 101 should be restored to display 2
         assert_eq!(state.windows.get(&101).unwrap().display_id, 2);
@@ -2928,7 +2995,9 @@ mod tests {
             .with_windows(vec![])
             .with_focused(None);
 
-        let _result = state.handle_display_change(&ws2);
+        state
+            .handle_display_change(&ws2)
+            .expect("display configuration changed");
 
         // visible_tags should be saved
         assert_eq!(state.saved_display_tags.get(&2), Some(&Tag::new(3)));
@@ -2942,7 +3011,9 @@ mod tests {
             .with_windows(vec![])
             .with_focused(None);
 
-        let _result = state.handle_display_change(&ws3);
+        state
+            .handle_display_change(&ws3)
+            .expect("display configuration changed");
 
         // visible_tags should be restored to tag 3
         assert_eq!(state.displays.get(&2).unwrap().visible_tags, Tag::new(3));
@@ -3005,7 +3076,9 @@ mod tests {
             ])
             .with_focused(Some(100));
 
-        let _result = state.handle_display_change(&ws2);
+        state
+            .handle_display_change(&ws2)
+            .expect("display configuration changed");
 
         // Verify window 101 is orphaned
         assert_eq!(state.windows.get(&101).unwrap().display_id, 1);
@@ -3026,7 +3099,9 @@ mod tests {
             ])
             .with_focused(Some(100));
 
-        let result = state.handle_display_change(&ws3);
+        let result = state
+            .handle_display_change(&ws3)
+            .expect("display configuration changed");
 
         // Window 101 should be restored to display 2
         assert_eq!(state.windows.get(&101).unwrap().display_id, 2);
@@ -3071,7 +3146,9 @@ mod tests {
             )])
             .with_focused(Some(100));
 
-        let _result = state.handle_display_change(&ws2);
+        state
+            .handle_display_change(&ws2)
+            .expect("display configuration changed");
 
         // Window should be on fallback display (1) with orphaned_from = 3
         assert_eq!(state.windows.get(&100).unwrap().display_id, 1);
@@ -3086,7 +3163,9 @@ mod tests {
             )])
             .with_focused(Some(100));
 
-        let _result = state.handle_display_change(&ws3);
+        state
+            .handle_display_change(&ws3)
+            .expect("display configuration changed");
 
         // Window is still on display 1, orphaned_from should still be 3 (not 1)
         assert_eq!(state.windows.get(&100).unwrap().display_id, 1);
@@ -3103,7 +3182,9 @@ mod tests {
             )])
             .with_focused(Some(100));
 
-        let _result = state.handle_display_change(&ws4);
+        state
+            .handle_display_change(&ws4)
+            .expect("display configuration changed");
 
         // Window should be restored to display 3
         assert_eq!(state.windows.get(&100).unwrap().display_id, 3);

--- a/yashiki/src/macos/display.rs
+++ b/yashiki/src/macos/display.rs
@@ -30,14 +30,20 @@ extern "C" {
     ) -> i32;
 }
 
+/// What woke the display source. Both variants mean the same thing to the
+/// handler -- re-read the configuration -- and travel the same channel so that a
+/// change reported through both collapses into one reconcile.
 #[derive(Debug, Clone)]
-pub struct DisplayReconfigEvent {
-    pub display_id: DisplayId,
-    pub flags: u32,
+pub enum DisplayChangeSignal {
+    /// CGDisplayRegisterReconfigurationCallback, one per affected display.
+    Reconfiguration { display_id: DisplayId, flags: u32 },
+    /// NSApplicationDidChangeScreenParameters. Carries nothing: it says the
+    /// screen list changed, and the geometry is read back from the OS anyway.
+    ScreenParameters,
 }
 
 struct DisplayCallbackState {
-    tx: Sender<DisplayReconfigEvent>,
+    tx: Sender<DisplayChangeSignal>,
     source_ptr: Arc<AtomicPtr<c_void>>,
 }
 
@@ -48,22 +54,33 @@ extern "C" fn display_reconfig_callback(
     flags: u32,
     _user_info: *mut c_void,
 ) {
-    if let Some(state) = DISPLAY_CALLBACK_STATE.get() {
-        let _ = state.tx.send(DisplayReconfigEvent { display_id, flags });
+    raise(DisplayChangeSignal::Reconfiguration { display_id, flags });
+}
 
-        // Signal the CFRunLoopSource to wake up the main thread
-        let source = state.source_ptr.load(Ordering::Acquire);
-        if !source.is_null() {
-            unsafe {
-                CFRunLoopSourceSignal(source as CFRunLoopSourceRef);
-                CFRunLoopWakeUp(CFRunLoopGetMain());
-            }
+/// Report a screen-parameter change on the same path as the reconfiguration
+/// callback. Called from the AppKit notification, which has no display to name.
+pub fn signal_screen_parameters_changed() {
+    raise(DisplayChangeSignal::ScreenParameters);
+}
+
+fn raise(signal: DisplayChangeSignal) {
+    let Some(state) = DISPLAY_CALLBACK_STATE.get() else {
+        return;
+    };
+    let _ = state.tx.send(signal);
+
+    // Signal the CFRunLoopSource to wake up the main thread
+    let source = state.source_ptr.load(Ordering::Acquire);
+    if !source.is_null() {
+        unsafe {
+            CFRunLoopSourceSignal(source as CFRunLoopSourceRef);
+            CFRunLoopWakeUp(CFRunLoopGetMain());
         }
     }
 }
 
 pub fn register_display_callback(
-    tx: Sender<DisplayReconfigEvent>,
+    tx: Sender<DisplayChangeSignal>,
     source_ptr: Arc<AtomicPtr<c_void>>,
 ) -> anyhow::Result<()> {
     DISPLAY_CALLBACK_STATE

--- a/yashiki/src/macos/display.rs
+++ b/yashiki/src/macos/display.rs
@@ -30,6 +30,10 @@ extern "C" {
     ) -> i32;
 }
 
+/// `kCGDisplayBeginConfigurationFlag`. Set on the callback that fires *before*
+/// the change, when the display metrics still describe the old configuration.
+const K_CG_DISPLAY_BEGIN_CONFIGURATION_FLAG: u32 = 1 << 0;
+
 /// What woke the display source. Both variants mean the same thing to the
 /// handler -- re-read the configuration -- and travel the same channel so that a
 /// change reported through both collapses into one reconcile.
@@ -54,6 +58,11 @@ extern "C" fn display_reconfig_callback(
     flags: u32,
     _user_info: *mut c_void,
 ) {
+    // Handling the pre-change notification would retile against stale geometry.
+    if flags & K_CG_DISPLAY_BEGIN_CONFIGURATION_FLAG != 0 {
+        return;
+    }
+
     raise(DisplayChangeSignal::Reconfiguration { display_id, flags });
 }
 

--- a/yashiki/src/macos/workspace.rs
+++ b/yashiki/src/macos/workspace.rs
@@ -103,12 +103,14 @@ pub fn terminate_process(pid: u32) {
     }
 }
 
+// Display events no longer travel this channel, so every remaining variant is an
+// app lifecycle notification. The shared prefix is the point.
+#[allow(clippy::enum_variant_names)]
 #[derive(Debug, Clone)]
 pub enum WorkspaceEvent {
     AppLaunched { pid: i32 },
     AppTerminated { pid: i32 },
     AppActivated { pid: i32 },
-    DisplaysChanged,
 }
 
 struct Ivars {
@@ -163,11 +165,7 @@ define_class!(
         #[unsafe(method(displaysChanged:))]
         fn displays_changed(&self, _notification: &NSNotification) {
             tracing::debug!("Screen parameters changed");
-            let tx = self.ivars().event_tx.borrow();
-            if let Some(sender) = tx.as_ref() {
-                let _: Result<(), _> = sender.send(WorkspaceEvent::DisplaysChanged);
-            }
-            signal_runloop_source(&self.ivars().source_ptr);
+            super::display::signal_screen_parameters_changed();
         }
     }
 );
@@ -253,9 +251,9 @@ impl WorkspaceWatcher {
                 None,
             );
 
-            // Register for screen change notifications using default notification center.
-            // Note: This notification doesn't work without NSApplication's event loop.
-            // Display changes are detected via polling in timer_callback instead.
+            // Menu bar visibility, resolution and arrangement changes arrive here.
+            // A real reconfiguration also fires the CoreGraphics callback; the
+            // handler drops whichever arrives second.
             let default_center = objc2_foundation::NSNotificationCenter::defaultCenter();
             let screen_changed_name =
                 NSString::from_str("NSApplicationDidChangeScreenParametersNotification");


### PR DESCRIPTION
Fixes #186.

## What

`NSApplicationDidChangeScreenParameters` was received and then discarded, on the assumption that `CGDisplayRegisterReconfigurationCallback` covered every geometry change. It does not, so changes reported only through the notification were never noticed: the daemon kept serving the geometry it read at startup, and subscribers were told nothing at all.

The notification is reported on the channel the reconfiguration callback already uses, which turns `DisplayReconfigEvent` into a two-variant `DisplayChangeSignal`. Both paths then signal the same `CFRunLoopSource`, so a real reconfiguration — which fires the notification and the callback together — is delivered as one callback for the pair, and the reconciliation runs once from a single place.

The sender and the run loop source are already held by the display module, so the workspace observer needs neither passed in and the handler needs no side-channel flag to tell it what woke it.

## Commits

| commit | what it does |
| --- | --- |
| `fix(display): follow screen-parameter changes` | handles the notification, converging both paths on one channel and one `CFRunLoopSource` so a burst reconciles once; a single hotplug previously produced eight callbacks and eight full retiles |
| `perf(display): ignore pre-change reconfiguration callbacks` | drops the `kCGDisplayBeginConfigurationFlag` pass, where `CGDisplayBounds` still describes the outgoing configuration |
| `perf(display): skip the retile when the configuration is unchanged` | reports no change when the configuration read from the OS is the one already held |

## `Option<DisplayChangeResult>`

The last commit changes `handle_display_change` to return `Option<DisplayChangeResult>` rather than an empty result.

The caller could not otherwise tell "nothing changed" from "no particular display needs a retile": it read an empty `displays_to_retile` as "no specific target, so do them all" and fell through to a full retile — the exact work the commit exists to avoid. It also emitted `display_updated` for every display on every reconcile, regardless of the result.

With the distinction in the type, the callback returns early on `None`, and the retile branch loses its fallback and drives the list it is handed. Every branch that returns `Some` fills that list in exhaustively, so an empty list means no display needs one.

## Behaviour change

No retile runs and no events are emitted for a no-op reconcile. Subscribers that relied on `display_updated` arriving on every screen-parameter notification, including ones that changed nothing, will see fewer events.

## Verification

- `cargo test --workspace` 312 passing, and each of the three commits builds on its own; `cargo clippy --all-targets` reports no new warnings.
- Exercised on hardware, with a subscriber attached and debug logging on:
  - **No-op** — Dock autohide toggled twice. It is a screen-parameter change that leaves the top edge alone, so the configuration compares equal: `Reconciling displays` → `Display configuration unchanged, nothing to do`, no retile, **0 events**. Before this change the same toggle produced a full retile and 4 `display_updated` events carrying identical payloads.
  - **Real change** — menu bar toggled between auto-hide and always-visible. The external display moves `2560x1080 @ (0,0)` ⇄ `2560x1050 @ (0,30)` and windows follow, without a daemon restart.
- The no-op behaviour has no automated coverage: the early return lives in the run loop source callback, which needs a window server to drive. The unit test asserts that `handle_display_change` reports no change; that the caller then does nothing is only shown by the run above.

## Environment

macOS 27.0 (26A5378n), Apple Silicon. Independent from the PR for #185.
