### PR TITLE
chore: fix clippy::question-mark lint in execute_effects

### DIFF
--- a/yashiki/src/app/effects.rs
+++ b/yashiki/src/app/effects.rs
@@ -137,19 +137,15 @@ pub fn execute_effects<M: WindowManipulator>(
                 manipulator.exec_command(&command, &path)?;
             }
             Effect::ExecCommandTracked { command, path } => {
-                match manipulator.exec_command_tracked(&command, &path) {
-                    Ok(pid) => {
-                        state
-                            .borrow_mut()
-                            .tracked_processes
-                            .push(crate::core::TrackedProcess {
-                                pid,
-                                _command: command.clone(),
-                            });
-                        tracing::info!("Tracked process started: {} (pid={})", command, pid);
-                    }
-                    Err(e) => return Err(e),
-                }
+                let pid = manipulator.exec_command_tracked(&command, &path)?;
+                state
+                    .borrow_mut()
+                    .tracked_processes
+                    .push(crate::core::TrackedProcess {
+                        pid,
+                        _command: command.clone(),
+                    });
+                tracing::info!("Tracked process started: {} (pid={})", command, pid);
             }
             Effect::UpdateLayoutExecPath { path } => {
                 layout_engine_manager.borrow_mut().set_exec_path(&path);


### PR DESCRIPTION
The `Lint` job currently fails on `main` with a single pre-existing
`clippy::question-mark` error in `yashiki/src/app/effects.rs`. This replaces the
`match` with `?`, which also matches the neighbouring `Effect::ExecCommand` arm.

Behaviour is unchanged: `exec_command_tracked` and `execute_effects` both use
`String` as the error type, so `?` propagates exactly as `return Err(e)` did.

Verified with the CI commands: `cargo test --all` (310 passed),
`cargo fmt --all --check`, `cargo clippy --all -- -D warnings`.